### PR TITLE
Add support for testing roles

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -50,7 +50,9 @@ module Kitchen
       default_config :ansible_yum_repo, "https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm"
       default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
 
-      default_config :playbook, 'site.yml'
+      default_config :playbook do |provisioner|
+        provisioner.calculate_path('site.yml', :file)
+      end
 
       default_config :roles_path do |provisioner|
          provisioner.calculate_path('roles') or
@@ -80,18 +82,20 @@ module Kitchen
 
 
 
-    #  def calculate_path(path, type = :directory)
-    #    base = config[:test_base_path]
-    #    candidates = []
-    #    candidates << File.join(base, instance.suite.name, 'ansible', path)
-    #    candidates << File.join(base, instance.suite.name, path)
-    #    candidates << File.join(base, path)
-    #    candidates << File.join(Dir.pwd, path)
-    #
-    #    candidates.find do |c|
-    #      type == :directory ? File.directory?(c) : File.file?(c)
-    #    end
-    #  end
+      def calculate_path(path, type = :directory)
+        base = config[:test_base_path]
+        candidates = []
+        candidates << File.join(base, instance.suite.name, 'ansible', path)
+        candidates << File.join(base, instance.suite.name, path)
+        candidates << File.join(base, path)
+        candidates << File.join(Dir.pwd, path)
+        candidates << File.join(Dir.pwd) if path == 'roles'
+    
+        debug("Calculating path for #{path}, candidates are: #{candidates.to_s}")
+        candidates.find do |c|
+          type == :directory ? File.directory?(c) : File.file?(c)
+        end
+      end
 
       def install_command
         return unless config[:require_ansible_omnibus] or config[:require_ansible_repo]
@@ -238,7 +242,7 @@ module Kitchen
             "-M #{File.join(config[:root_path], 'modules')}",
             ansible_verbose_flag,
             extra_vars,
-            "#{File.join(config[:root_path], config[:playbook])}",
+            "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
           ].join(" ")
         end
 
@@ -281,6 +285,10 @@ module Kitchen
 
         def roles
           config[:roles_path]
+        end
+
+        def role_name
+          File.basename(roles) == 'roles' ? '' : File.basename(roles)
         end
 
         def modules
@@ -349,7 +357,6 @@ module Kitchen
           
           # Detect whether we are running tests on a role
           # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
-          role_name = File.basename(roles) == 'roles' ? '' : File.basename(roles)
 
           FileUtils.mkdir_p(File.join(tmp_roles_dir, role_name))
           FileUtils.cp_r(Dir.glob("#{roles}/*"), File.join(tmp_roles_dir, role_name))
@@ -366,9 +373,9 @@ module Kitchen
                file.write("#no roles path specified\n")
             end
           else
-            debug("Using role from #{roles}")
+            debug("Setting roles_path inside VM to #{File.join(config[:root_path], 'roles', role_name)}")
             File.open( ansible_config_file, "wb") do |file|
-               file.write("[defaults]\nroles_path = #{File.join(config[:root_path], roles)}\n")
+               file.write("[defaults]\nroles_path = #{File.join(config[:root_path], 'roles', role_name)}\n")
             end
           end
         end


### PR DESCRIPTION
Hello again @neillturner,

In response to my own issue/feature request in #2, I've managed to develop a working proof of concept for testing roles!

I'm using a common pattern borrowed from Chef cookbook development where a wrapper/test-harness cookbook is created in order to test another cookbook or LWRP.  In this pattern, a folder structure is created under `test/integration/` where a `cookbooks` directory is placed containing a wrapper cookbook for use in order to run integration tests for one cookbook with other cookbooks, or to test LWRPs defined within the cookbook.  For example, the [lsyncd cookbook](https://github.com/dgivens/chef-lsyncd) has an example of this in [`test/fixtures/cookbooks/lsyncd_test`](https://github.com/dgivens/chef-lsyncd/tree/master/test/fixtures/cookbooks/lsyncd_test), and uses the [`Berksfile`](https://github.com/dgivens/chef-lsyncd/blob/master/Berksfile) to download this cookbook to a `cookbooks` directory inside the `sandbox_path` before copying it inside the VM.  This may be a useful pattern to follow in the future for installing other Ansible role dependencies (e.g.: with an `Ansiblefile` and `librarian-ansible`, or other Bundler-like tool for installing roles from Ansible Galaxy).

My current implementation for testing a single role simply leverages the `calculate_paths` method to resolve the `roles_path` to the current working directory (e.g.: If I'm working on the `foobar` role, I'll be in a top-level directory called "`foobar`" which needs to be copied into the `sandbox_path` under 'roles', and then into the VM under `/tmp/kitchen/roles/foobar`.  It expects a directory structure under `test/integration/default/ansible` to contain a basic wrapper playbook called `site.yml` by default, and optionally `hosts`, `modules`, `host_vars`, and `group_vars` too.  These all get copied to the `sandbox_path` first and then end up inside the test-kitchen VM under the `kitchen_root` (`/tmp/kitchen/`).  The `ansible.cfg` is generated to point the `roles_path` at `/tmp/kitchen/roles`.  Finally, `Kitchen::Provisioner::AnsiblePlaybook#run_command` kicks off `ansible-playbook` and points it at the `site.yml` playbook under `/tmp/kitchen/`.

For example, my role directory structure for a `foobar` role would look like:

```
~/src/ansible/roles/foobar
├── README.md
├── defaults
│   └── main.yml
├── files
├── handlers
│   └── main.yml
├── meta
│   └── main.yml
├── tasks
│   └── main.yml
├── templates
├── test
│   └── integration
│       └── default
│           ├── ansible
│           │   ├── group_vars
│           │   ├── host_vars
│           │   ├── hosts
│           │   ├── modules
│           │   └── site.yml
│           └── serverspec
│               └── foobar_spec.rb
└── vars
    └── main.yml
```

A basic wrapper `site.yml` file might look like:

```

---
# This playbook deploys the foobar role for testing

- hosts: test-kitchen
  user: root

  roles:
    - foobar
```

The directory structure copied into `/tmp/kitchen` looks like:

```
/tmp/kitchen/
├── ansible.cfg
├── group_vars
├── hosts
├── host_vars
├── modules
├── roles
│   └── foobar
│       ├── defaults
│       │   └── main.yml
│       ├── files
│       ├── handlers
│       │   └── main.yml
│       ├── meta
│       │   └── main.yml
│       ├── README.md
│       ├── tasks
│       │   └── main.yml
│       ├── templates
│       ├── test
│       │   └── integration
│       │       └── default
│       │           ├── ansible
│       │           │   ├── group_vars
│       │           │   ├── hosts
│       │           │   ├── host_vars
│       │           │   ├── modules
│       │           │   └── site.yml
│       │           └── serverspec
│       │               └── foobar_spec.rb
│       └── vars
│           └── main.yml
└── site.yml
```

One thing I wasn't sure about was [this section of Kitchen::Provisioner::AnsiblePlaybook#prepare_command](https://github.com/neillturner/kitchen-ansible/blob/master/lib/kitchen/provisioner/ansible_playbook.rb#L214-227).  My initial instinct is to want to clean this up by only copying what's absolutely necessary to `/etc/ansible`, which would probably be just `ansible.cfg`; and therefore simply just add settings to `ansible.cfg` that point to appropriate paths in `/tmp/kitchen` for `group_vars`, and `host_vars`.  According to the [ansible documentation on configuration settings](http://docs.ansible.com/intro_configuration.html), I don't seem to see any appropriate settings for `group_vars` and `host_vars`; Thus, I've left things as they are for now.  I have been told that `ansible-playbook` figures out the paths for those by using the same directory that is passed for the inventory host file via `-i` (yet haven't verified this myself yet).  So having them in two places isn't necessarily bad at the moment, but we may want to clean that up so they only live in `/tmp/kitchen`.

Let me know what you think of this implementation of test-kitchen within roles!
