### PR TITLE
Serialize extra_vars as json

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -309,8 +309,8 @@ module Kitchen
 
         def extra_vars
           return nil if config[:extra_vars].none?
-          bash_vars = config[:extra_vars].map { |k,v| "#{k}=#{v}" }.join(" ")
-          bash_vars = "-e \"#{bash_vars}\""
+          bash_vars = JSON.dump(config[:extra_vars])
+          bash_vars = "-e '#{bash_vars}'"
           debug(bash_vars)
           bash_vars
         end


### PR DESCRIPTION
Now complex extra-vars can be passed to ansible. For example, arrays:

```
extra_vars:
  my_var:
    - 1
    - 2
```
