### PR TITLE
Fixing librarian-ansible so it works!!

### DIFF
--- a/lib/kitchen/provisioner/ansible/librarian.rb
+++ b/lib/kitchen/provisioner/ansible/librarian.rb
@@ -45,7 +45,7 @@ module Kitchen
 
         def resolve
           version = ::Librarian::Ansible::VERSION
-          info("Resolving module dependencies with Librarian-Ansible #{version}...")
+          info("Resolving role dependencies with Librarian-Ansible #{version}...")
           debug("Using Ansiblefile from #{ansiblefile}")
 
           env = ::Librarian::Ansible::Environment.new(

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -354,7 +354,9 @@ module Kitchen
         def prepare_roles
           info('Preparing roles')
           debug("Using roles from #{roles}")
-          
+
+          resolve_with_librarian if File.exists?(ansiblefile)
+                    
           # Detect whether we are running tests on a role
           # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
 
@@ -373,9 +375,9 @@ module Kitchen
                file.write("#no roles path specified\n")
             end
           else
-            debug("Setting roles_path inside VM to #{File.join(config[:root_path], 'roles', role_name)}")
+            debug("Setting roles_path inside VM to #{File.join(config[:root_path], 'roles')}")
             File.open( ansible_config_file, "wb") do |file|
-               file.write("[defaults]\nroles_path = #{File.join(config[:root_path], 'roles', role_name)}\n")
+               file.write("[defaults]\nroles_path = #{File.join(config[:root_path], 'roles')}\n")
             end
           end
         end
@@ -442,14 +444,11 @@ module Kitchen
           else
             info 'nothing to do for modules'
           end
-
-          resolve_with_librarian if File.exists?(ansiblefile)
-
         end
 
         def resolve_with_librarian
           Kitchen.mutex.synchronize do
-            Ansible::Librarian.new(ansiblefile, tmp_modules_dir, logger).resolve
+            Ansible::Librarian.new(ansiblefile, tmp_roles_dir, logger).resolve
           end
         end
     end


### PR DESCRIPTION
In Ansible, `roles` are the community-shareable unit of configuration management code distributed through the [Ansible Galaxy Site](https://galaxy.ansible.com).  Although modules are indeed also developed by the community and shared via the [modules-extras project](http://github.com/ansible/ansible-modules-extras), the [Ansible Modules Documentation]() has a note saying that they're incorporated into Ansible core and packaged alongside Ansible:

>  Should you develop an interesting Ansible module, consider sending a pull request to the modules-extras project. There’s also a core repo for more established and widely used modules. “Extras” modules may be promoted to core periodically, but there’s no fundamental difference in the end - both ship with ansible, all in one package, regardless of how you acquire ansible.

Therefore, the use case for [`librarian-ansible`](https://github.com/bcoe/librarian-ansible) or a bundler-like tool is more applicable to installing [Ansible Roles](http://docs.ansible.com/playbooks_roles.html#ansible-galaxy) from Galaxy.

**Changes:**
- Move `resolve_with_librarian` to `#prepare_roles` function
- Ensure roles in Ansiblefile are installed to sandbox roles path: `tmp_roles_dir`
- Fix `roles_path` in `ansible.cfg` so it points to top-level roles dir in `kitchen_root` (e.g.: `/tmp/kitchen/roles`)
