### PR TITLE
Make the default playbook name `default.yml`, and add error message for how to use this with a role or with `provisioner: playbook:` variable setting

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -51,7 +51,8 @@ module Kitchen
       default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
 
       default_config :playbook do |provisioner|
-        provisioner.calculate_path('site.yml', :file)
+        provisioner.calculate_path('default.yml', :file) or
+          raise "No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default wrapper playbook for your role in test/integration/playbooks/default.yml or test/integration/default.yml"
       end
 
       default_config :roles_path do |provisioner|


### PR DESCRIPTION
After searching around for a while, it seemed that there wasn't a
convention set up for a default playbook name in the Ansible community.

The default name I chose before 'site.yml' was only based on the ansible/ansible-examples repo,
as most of the playbooks there are for lamp or webserver stacks, hence `site.yml`.  However,
in Ansible, playbook names are probably more related to the tasks that the plays perform.
For playbooks, it wouldn't make sense here to enforce a default playbook name on people
(although I'm a fan of [convention over configuration](http://en.wikipedia.org/wiki/Convention_over_configuration)).  However, for roles it makes sense
because they need to be wrapped in a playbook, and since they will be shared & treated like cookbooks are
in the Chef community it makes sense to set a convention for a `default.yml` wrapper role in `test/integration/`
somewhere.  Whether the user puts it in `test/integration/playbooks` or just `test/integration` is up to them.
The path search function will allow for these structures to be used.  This should also allow for multiple
test suites to set the playbook that they will call, enabling different wrapper playbooks for different suites
(to set variables & test different behaviors etc...).  It also should allow for a structure under `playbooks` to develop
with custom host_vars, group_vars, and other Ansible-specific settings. **Note:** I haven't fully tested this or needed this use case yet, but in theory it's possible due to the `calculate_path` function being used for: `playbook`, `roles_path`, `group_vars_path`, `host_vars_path`, `modules_path`, and `ansiblefile_path`.
