### PR TITLE
Add support for downloading dependencies with ansible-galaxy

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -76,6 +76,7 @@ module Kitchen
         provisioner.calculate_path('Ansiblefile', :file)
       end
 
+      default_config :requirements_path, false
       default_config :ansible_verbose, false
       default_config :ansible_verbosity, 1
       default_config :ansible_noop, false   # what is ansible equivalent of dry_run???? ##JMC: I think it's [--check mode](http://docs.ansible.com/playbooks_checkmode.html) TODO: Look into this...
@@ -275,6 +276,13 @@ module Kitchen
               sudo('cp -r'), File.join(config[:root_path],'host_vars'), '/etc/ansible/.',
           ].join(' ')
 
+          if galaxy_requirements
+            commands << [
+               sudo('ansible-galaxy'), 'install', '--force',
+               '-r', File.join(config[:root_path], galaxy_requirements),
+            ].join(' ')
+          end
+
           command = commands.join(' && ')
           debug(command)
           command
@@ -319,6 +327,10 @@ module Kitchen
 
         def ansiblefile
           config[:ansiblefile_path] or ''
+        end
+
+        def galaxy_requirements
+          config[:requirements_path] or nil
         end
 
         def playbook
@@ -406,6 +418,10 @@ module Kitchen
           debug("Using roles from #{roles}")
 
           resolve_with_librarian if File.exists?(ansiblefile)
+
+          if galaxy_requirements
+            FileUtils.cp(galaxy_requirements, File.join(sandbox_path, galaxy_requirements))
+          end
                     
           # Detect whether we are running tests on a role
           # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -22,6 +22,7 @@ ansible_verbosity| 1| Sets the verbosity flag appropriately (e.g.: `1 => '-v', 2
 update_package_repos| true| update OS repository metadata
 chef_bootstrap_url |"https://www.getchef.com/chef/install.sh"| the chef (needed for busser to run tests)
 ansiblefile_path | | Path to Ansiblefile
+requirements_path | | Path to ansible-galaxy requirements
 
 ## Configuring Provisioner Options
 


### PR DESCRIPTION
This lets users use the ansible-galaxy command that's bundled with Ansible to download dependencies.