### PR TITLE
Added support for 'tags'. Settings 'extra_vars' and 'tags' attributes ca...

### DIFF
--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -53,11 +53,16 @@ The provisioner can be configured globally or per suite, global settings act as 
 
 in this example, vagrant will download a box for ubuntu 1204 with no configuration management installed, then install the latest ansible and ansible playbook against a ansible repo from the /repository/ansible_repo directory using the defailt manifest site.yml
 
-To override a setting at the suite-level, specify the setting name under the suite:
+To override a setting at the suite-level, specify the setting name under the suite's attributes:
 
     suites:
-     - name: default
-       playbook: foobar.yml
+     - name: server
+       attributes:
+         extra_vars:
+           server_installer_url: http://downloads.app.com/v1.0
+         tags:
+           - server
+
 
 ### Per-suite Structure
 


### PR DESCRIPTION
This adds [Ansible Tags](http://docs.ansible.com/playbooks_tags.html) to the provisioner settings. Additionally, 'tags' and 'extra_vars' can now effectively be overridden on a per-suite (see changes in ```provisioner_options.md```).

This pull request closes issues [#20](https://github.com/neillturner/kitchen-ansible/issues/20) and [#21]([https://github.com/neillturner/kitchen-ansible/issues/21).

Best, Martin