### PR TITLE
Run apt-get update early

### DIFF
--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -138,6 +138,7 @@ module Kitchen
           info("Installing ansible on #{ansible_platform}")
           <<-INSTALL
           if [ ! $(which ansible) ]; then
+           #{update_packages_debian_cmd}
             ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
             #{sudo('apt-get')} -y install apt-utils
             ## Fix debconf tty warning messages
@@ -150,7 +151,6 @@ module Kitchen
           #  #{sudo('dpkg')} -i #{ansible_apt_repo_file}
           #  #{sudo('apt-get')} -y autoremove ## These autoremove/autoclean are sometimes useful but
           #  #{sudo('apt-get')} -y autoclean  ## don't seem necessary for the Ubuntu OpsCode bento boxes that are not EOL by Canonical
-          #  #{update_packages_debian_cmd}
           #  #{sudo('apt-get')} -y --force-yes install ansible#{ansible_debian_version} python-selinux
             ## 10.04 version of add-apt-repository doesn't accept --yes
             ## later versions require interaction from user, so we must specify --yes
@@ -183,6 +183,7 @@ module Kitchen
                #{update_packages_redhat_cmd}
                #{sudo('yum')} -y install ansible#{ansible_redhat_version} libselinux-python
             else
+           #{update_packages_debian_cmd}
            ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
             #{sudo('apt-get')} -y install apt-utils
             ## Fix debconf tty warning messages
@@ -195,7 +196,6 @@ module Kitchen
           #  #{sudo('dpkg')} -i #{ansible_apt_repo_file}
           #  #{sudo('apt-get')} -y autoremove ## These autoremove/autoclean are sometimes useful but
           #  #{sudo('apt-get')} -y autoclean  ## don't seem necessary for the Ubuntu OpsCode bento boxes that are not EOL by Canonical
-          #  #{update_packages_debian_cmd}
           #  #{sudo('apt-get')} -y --force-yes install ansible#{ansible_debian_version} python-selinux
             ## 10.04 version of add-apt-repository doesn't accept --yes
             ## later versions require interaction from user, so we must specify --yes


### PR DESCRIPTION
Hi Neil,

I, too, had some problems with Issue #19 - If you would be so kind to review this PR, thanks!

Additional Notes:
* The code was already there, but commented out. I enabled the code and moved it to be ran early.
* I have tested with update_package_repos true and false, with true the converged machine gets ansible_version that I have specified. With false, the converged machine gets an old ansible version.
* I made the version bump in a separate commit in case you don't want to bump the version of the gem.

Let me know if you have any additional requests!