### PR TITLE
additional_copy_path

### DIFF
--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -65,6 +65,10 @@ module Kitchen
          provisioner.calculate_path('group_vars', :directory)
       end
 
+      default_config :additional_copy_path do |provisioner|
+         provisioner.calculate_path('addt_dir', :directory)
+      end
+
       default_config :host_vars_path do |provisioner|
          provisioner.calculate_path('host_vars', :directory)
       end
@@ -263,6 +267,7 @@ module Kitchen
           prepare_roles
           prepare_ansible_cfg
           prepare_group_vars
+          prepare_addt_dir
           prepare_host_vars
           prepare_hosts
           info('Finished Preparing files for transfer')
@@ -370,6 +375,10 @@ module Kitchen
 
         def group_vars
           config[:group_vars_path].to_s
+        end
+
+        def addt_dir
+          config[:additional_copy_path].to_s
         end
 
         def host_vars
@@ -514,6 +523,20 @@ module Kitchen
 
           debug("Using group_vars from #{group_vars}")
           FileUtils.cp_r(Dir.glob("#{group_vars}/*"), tmp_group_vars_dir)
+        end
+
+        def prepare_addt_dir
+          info('Preparing additional_copy_path')
+          tmp_addt_dir = File.join(sandbox_path, File.basename(addt_dir))
+          FileUtils.mkdir_p(tmp_addt_dir)
+
+          unless File.directory?(addt_dir)
+            info 'nothing to do for additional_copy_path'
+            return
+          end
+
+          debug("Using additional_copy_path from #{addt_dir}")
+          FileUtils.cp_r(Dir.glob("#{addt_dir}/*"), tmp_addt_dir)
         end
 
         def prepare_host_vars

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -14,6 +14,7 @@ ansible_omnibus_remote_path | "/opt/ansible" | Server Installation location of a
 roles_path | roles | ansible repo roles directory
 group_vars_path | group_vars | ansible repo group_vars directory
 host_vars_path | host_vars | ansible repo hosts directory
+additional_copy_path | | arbitrary directory to copy into test environment, relative to CWD. (eg, vars)
 extra_vars | Hash.new | Hash to set the extra_vars passed to ansibile-playbook command
 playbook | 'site.yml' | playbook for ansible-playbook to run
 modules_path | | ansible repo manifests directory


### PR DESCRIPTION
When testing an ansible playbook, I was having to invent ways to get the test environment to include a directory, like a task dir or a vars dir. So, I wrote this to additionally copy a directory from CWD.

While this isn't the best solution, I feel like it will help some people. I welcome your comments. Thanks in advance!