### PR TITLE
Adding capability to set --diff mode

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -314,6 +314,7 @@ module Kitchen
             "-M #{File.join(config[:root_path], 'modules')}",
             ansible_verbose_flag,
             ansible_check_flag,
+            ansible_diff_flag,
             extra_vars,
             tags,
             "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
@@ -399,6 +400,10 @@ module Kitchen
 
         def ansible_check_flag
           config[:ansible_check] ? '--check' : nil
+        end
+
+        def ansible_diff_flag
+          config[:ansible_diff] ? '--diff' : nil
         end
 
         def ansible_platform

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -84,7 +84,8 @@ module Kitchen
       default_config :requirements_path, false
       default_config :ansible_verbose, false
       default_config :ansible_verbosity, 1
-      default_config :ansible_noop, false   # what is ansible equivalent of dry_run???? ##JMC: I think it's [--check mode](http://docs.ansible.com/playbooks_checkmode.html) TODO: Look into this...
+      default_config :ansible_check, false
+      default_config :ansible_diff, false
       default_config :ansible_platform, ''
       default_config :update_package_repos, true
 

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -20,6 +20,8 @@ playbook | 'site.yml' | playbook for ansible-playbook to run
 modules_path | | ansible repo manifests directory
 ansible_verbose| false| Extra information logging
 ansible_verbosity| 1| Sets the verbosity flag appropriately (e.g.: `1 => '-v', 2 => '-vv', 3 => '-vvv" ...`) Valid values are one of: `1, 2, 3, 4` OR `:info, :warn, :debug, :trace`.
+ansible_check| false| Sets the `--check` flag when running Ansible
+ansible_diff| false| Sets the `--diff` flag when running Ansible
 update_package_repos| true| update OS repository metadata
 chef_bootstrap_url |"https://www.getchef.com/chef/install.sh"| the chef (needed for busser to run tests)
 ansiblefile_path | | Path to Ansiblefile
@@ -40,6 +42,7 @@ The provisioner can be configured globally or per suite, global settings act as 
       require_ansible_repo: true
       ansible_verbose: true
       ansible_verbosity: 2
+      ansible_diff: true
 
     platforms:
     - name: nocm_ubuntu-12.04


### PR DESCRIPTION
@neillturner: I'm adding this as a Pull Request because I'm in the habit of code reviews &
  I'd like to have comments/suggestions for things I add.  Let me know if this bugs you or if
  you feel like you don't have enough time to go over changes if I ever start pushing a lot.

  - Added `ansible_diff` kitchen config option to set `--diff` flag on ansible run
  - Added default `false` for `ansible_check` and `ansible_diff` mode


Part of me wants to default `ansible_diff` to true since it's so useful...

Also not sure if `ansible_noop` should be the standard config setting across `kitchen-ansible` vs. `kitchen-puppet`, or if `ansible_check` is probably best since `--check` and `--diff` are more familiar and people will expect a similar pattern to `--noop` for `ansible-puppet`.

What do you think?