### PR TITLE
When installing dependent roles with galaxy, they need to be in the corr...

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -303,7 +303,8 @@ module Kitchen
 
           if galaxy_requirements
             commands << [
-               sudo('ansible-galaxy'), 'install', '--force',
+               'ansible-galaxy', 'install', '--force',
+               '-p', File.join(config[:root_path], 'roles'),
                '-r', File.join(config[:root_path], galaxy_requirements),
             ].join(' ')
           end


### PR DESCRIPTION
...ect roles path

I came across this issue while using kitchen-ansible to test a new role that had dependencies on other roles. The previous behavior seems to have been to install roles sourced via galaxy to /etc/ansible/roles, whereas /etc/ansible/ansible.cfg configures the roles path to be /tmp/kitchen/roles