### PR TITLE
Make vault file config optional

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansible (0.0.11)
+    kitchen-ansible (0.0.14)
       test-kitchen
 
 GEM
@@ -33,7 +33,7 @@ GEM
     rspec-support (3.2.2)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    test-kitchen (1.3.1)
+    test-kitchen (1.4.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (~> 2.7)

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -643,9 +643,12 @@ module Kitchen
         end
 
         def prepare_ansible_vault_password_file
-          info('Preparing ansible vault password')
-          debug("Copying ansible vault password file from #{ansible_vault_password_file} to #{tmp_ansible_vault_password_file_path}")
-          FileUtils.cp(ansible_vault_password_file, tmp_ansible_vault_password_file_path)
+          if ansible_vault_password_file
+            info('Preparing ansible vault password')
+            debug("Copying ansible vault password file from #{ansible_vault_password_file} to #{tmp_ansible_vault_password_file_path}")
+
+            FileUtils.cp(ansible_vault_password_file, tmp_ansible_vault_password_file_path)
+          end
         end
 
         def resolve_with_librarian

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -26,6 +26,9 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
 
   let(:logged_output)   { StringIO.new }
   let(:logger)          { Logger.new(logged_output) }
+  let(:platform) do
+    platform = instance_double(Kitchen::Platform, :os_type => nil)
+  end
 
   let(:config) do
     {
@@ -41,7 +44,11 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
   end
 
   let(:instance) do
-    instance_double("Kitchen::Instance", :name => "coolbeans", :logger => logger, :suite => suite)
+    instance_double("Kitchen::Instance", 
+      :name => "coolbeans",
+      :logger => logger,
+      :suite => suite,
+      :platform => platform)
   end
 
   let(:provisioner) do

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -35,7 +35,8 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       :test_base_path => "/b",
       :kitchen_root => "/r",
       :log_level => :info,
-      :playbook => "playbook.yml"
+      :playbook => "playbook.yml",
+      :ansible_vault_password_file => 'spec/fixtures/vault_password_file'
     }
   end
 
@@ -58,6 +59,24 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
   describe "#run_command" do
     it "should give a sane run_command" do
       expect(provisioner.run_command).to match(/ansible-playbook/)
+    end
+  end
+
+  describe "#prepare_ansible_vault_password_file" do
+    
+    it "copies the password file to the sandbox when present" do
+      allow(provisioner).to receive(:sandbox_path).and_return(Dir.tmpdir)
+      provisioner.send(:prepare_ansible_vault_password_file)
+    end
+    
+    it "noops when the ansible_vault_password_file is not configured" do
+      provision_without_vault_configured = Kitchen::Provisioner::AnsiblePlaybook.new(
+        config.tap{|config| config.delete(:ansible_vault_password_file)}
+      ).finalize_config!(instance)
+
+      allow(provision_without_vault_configured).to receive(:sandbox_path).and_return(Dir.tmpdir)
+
+      expect{ provision_without_vault_configured.send(:prepare_ansible_vault_password_file) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
This fixes a bug I have observed when no ansible-vault-password file is configured or otherwise present. Trace I was getting was:


```
       Preparing ansible vault password
D      Calculating path for ansible-vault-password, candidates are: ["/sample-project/test/integration/default/ansible/ansible-vault-password", "/sample-project/test/integration/default/ansible-vault-password", "/sample-project/test/integration/ansible-vault-password", "/sample-project/ansible-vault-password"]
D      Calculating path for ansible-vault-password, candidates are: ["/sample-project/test/integration/default/ansible/ansible-vault-password", "/sample-project/test/integration/default/ansible-vault-password", "/sample-project/test/integration/ansible-vault-password", "/sample-project/ansible-vault-password"]
D      Cleaning up local sandbox in /var/folders/lv/4cz_jj9n1_1433x_58ff8820gcjlx_/T/default-trusty64-sandbox-20150511-2745-jsg0uk
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #converge action: [can't convert nil into String]
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration

D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #converge action: [can't convert nil into String]
D      ---Nested Exception---
D      Class: TypeError
D      Message: can't convert nil into String
D      ------Backtrace-------
D      /Users/someuser/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/kitchen-ansible-0.0.14/lib/kitchen/provisioner/ansible_playbook.rb:372:in `basename'
D      /Users/someuser/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/kitchen-ansible-0.0.14/lib/kitchen/provisioner/ansible_playbook.rb:372:in `tmp_ansible_vault_password_file_path'
D      /Users/someuser/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/kitchen-ansible-0.0.14/lib/kitchen/provisioner/ansible_playbook.rb:647:in `prepare_ansible_vault_password_file'
D      /Users/someuser/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/kitchen-ansible-0.0.14/lib/kitchen/provisioner/ansible_playbook.rb:283:in `create_sandbox'
D      /Users/someuser/.rbenv/versions/1.9.3-p551/lib/ruby/gems/1.9.1/gems/test-kitchen-1.4.0/lib/kitchen/provisioner/base.rb:61:in `call'
```