### PR TITLE
Issue #54 - changes to allow files and folders to be referenced in additional_copy_path

### DIFF
--- a/kitchen-ansible.gemspec
+++ b/kitchen-ansible.gemspec
@@ -27,8 +27,8 @@ Supports running ansible-playbook
 
 EOF
   s.add_runtime_dependency 'test-kitchen'
-  
+
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'pry'
-
+  s.add_runtime_dependency 'librarian-ansible'
 end

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = '0.0.17'
+    VERSION = '0.0.15'
   end
 end

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.15"
+    VERSION = '0.0.17'
   end
 end

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = '0.0.15'
+    VERSION = "0.0.15"
   end
 end

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -16,7 +16,7 @@ roles_path | roles | ansible repo roles directory
 group_vars_path | group_vars | ansible repo group_vars directory
 host_vars_path | host_vars | ansible repo hosts directory
 filter_plugins | filter_plugins | ansible repo filter_plugins directory
-additional_copy_path | | arbitrary array of directories to copy into test environment, relative to CWD. (eg, vars)
+additional_copy_path | | arbitrary array of files and directories to copy into test environment, relative to CWD. (eg, vars or included playbooks)
 extra_vars | Hash.new | Hash to set the extra_vars passed to ansibile-playbook command
 playbook | 'site.yml' | playbook for ansible-playbook to run
 modules_path | | ansible repo manifests directory


### PR DESCRIPTION
Sorry didn't get this finished on Friday as promised... I've added support for files and folders to be added to `additional_copy_path`

Contrived example of why I need this coming right up :)

I have a playbook that I want to test, `a.yml`, that looks like so:

```yaml
- include: b.yml
```
Currently I cannot write a kitchen test for `a.yml` as `b.yml` will not be copied onto the target host. 

With this pull request applied I can add a line to my `additional_copy_path`  to ensure it is available on the target:

In `.kitchen.yml`:

```yaml
suites:
  - name: default
    provisioner:
      playbook: a.yml
      additional_copy_path:
       - callback_plugins
       - b.yml
```

The test for `a.yml` now works fine...
