### PR TITLE
Split config into it's own object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     kitchen-ansible (0.0.16)
+      librarian-ansible
       test-kitchen
 
 GEM
@@ -9,8 +10,18 @@ GEM
   specs:
     coderay (1.1.0)
     diff-lcs (1.2.5)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    highline (1.7.2)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-ansible (1.0.6)
+      faraday
+      librarian (~> 0.1.0)
     method_source (0.8.2)
-    mixlib-shellout (2.0.1)
+    mixlib-shellout (2.1.0)
+    multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'rspec/core/rake_task'
+ 
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  t.rspec_opts = '--format documentation'
+end

--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -1,0 +1,140 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Neill Turner (<neillwturner@gmail.com>)
+#
+# Copyright (C) 2013,2014 Neill Turner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# See https://github.com/neillturner/kitchen-ansible/blob/master/provisioner_options.md
+# for documentation configuration parameters with ansible_playbook provisioner.
+#
+
+require 'json'
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      #
+      # Ansible Playbook provisioner.
+      #
+      class Config
+        include Kitchen::Configurable
+
+        attr_reader :instance
+
+        default_config :ansible_verbose, false
+        default_config :require_ansible_omnibus, false
+        default_config :ansible_omnibus_url, nil
+        default_config :ansible_omnibus_remote_path, '/opt/ansible'
+        default_config :ansible_version, nil
+        default_config :require_ansible_repo, true
+        default_config :extra_vars, {}
+        default_config :tags, []
+        default_config :ansible_apt_repo, "ppa:ansible/ansible"
+        default_config :ansible_yum_repo, "https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm"
+        default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
+        default_config :requirements_path, false
+        default_config :ansible_verbose, false
+        default_config :ansible_verbosity, 1
+        default_config :ansible_check, false
+        default_config :ansible_diff, false
+        default_config :ansible_platform, ''
+        default_config :update_package_repos, true
+
+        default_config :playbook do |provisioner|
+          provisioner.calculate_path('default.yml', :file) or
+            raise "No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default wrapper playbook for your role in test/integration/playbooks/default.yml or test/integration/default.yml"
+        end
+
+        default_config :roles_path do |provisioner|
+          provisioner.calculate_path('roles') or
+            raise 'No roles_path detected. Please specify one in .kitchen.yml'
+        end
+
+        default_config :group_vars_path do |provisioner|
+          provisioner.calculate_path('group_vars', :directory)
+        end
+
+        default_config :additional_copy_path do |provisioner|
+          provisioner.calculate_path('additional_copy', :directory)
+        end
+
+        default_config :host_vars_path do |provisioner|
+          provisioner.calculate_path('host_vars', :directory)
+        end
+
+        default_config :modules_path do |provisioner|
+          provisioner.calculate_path('modules', :directory)
+        end
+
+        default_config :ansiblefile_path do |provisioner|
+          provisioner.calculate_path('Ansiblefile', :file)
+        end
+
+        default_config :filter_plugins_path do |provisioner|
+          provisioner.calculate_path('filter_plugins', :directory)
+        end
+
+        default_config :ansible_vault_password_file do |provisioner|
+          provisioner.calculate_path('ansible-vault-password', :file)
+        end
+
+        def initialize(config = {})
+          init_config(config)
+        end
+
+        def set_instance(instance)
+          @instance = instance
+        end
+
+        def []=(attr, val)
+          config[attr] = val
+        end
+
+        def [](attr)
+          config[attr]
+        end
+
+        def key?(k)
+          return config.key?(k)
+        end
+
+        def calculate_path(path, type = :directory)
+
+          if not instance
+            raise "Please ensure that an instance is provided before calling calculate_path"
+          end
+
+          base = config[:test_base_path]
+          candidates = []
+          candidates << File.join(base, instance.suite.name, 'ansible', path)
+          candidates << File.join(base, instance.suite.name, path)
+          candidates << File.join(base, path)
+          candidates << File.join(Dir.pwd, path)
+          candidates << File.join(Dir.pwd) if path == 'roles'
+
+          candidates.find do |c|
+            type == :directory ? File.directory?(c) : File.file?(c)
+          end
+        end
+
+
+      end
+
+    end
+  end
+
+end

--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 #
-# Author:: Neill Turner (<neillwturner@gmail.com>)
+# Author:: Michael Heap (<m@michaelheap.com>)
 #
-# Copyright (C) 2013,2014 Neill Turner
+# Copyright (C) 2015 Michael Heap
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# See https://github.com/neillturner/kitchen-ansible/blob/master/provisioner_options.md
-# for documentation configuration parameters with ansible_playbook provisioner.
 #
 
 require 'json'

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -22,6 +22,7 @@
 
 require 'json'
 require 'kitchen/provisioner/base'
+require 'kitchen/provisioner/ansible/config'
 require 'kitchen/provisioner/ansible/librarian'
 
 module Kitchen
@@ -40,62 +41,15 @@ module Kitchen
     class AnsiblePlaybook < Base
       attr_accessor :tmp_dir
 
-      default_config :require_ansible_omnibus, false
-      default_config :ansible_omnibus_url, nil
-      default_config :ansible_omnibus_remote_path, '/opt/ansible'
-      default_config :ansible_version, nil
-      default_config :require_ansible_repo, true
-      default_config :extra_vars, {}
-      default_config :tags, []
-      default_config :ansible_apt_repo, "ppa:ansible/ansible"
-      default_config :ansible_yum_repo, "https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm"
-      default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
-
-      default_config :playbook do |provisioner|
-        provisioner.calculate_path('default.yml', :file) or
-          raise "No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default wrapper playbook for your role in test/integration/playbooks/default.yml or test/integration/default.yml"
+      def initialize(provisioner_config)
+        config = Kitchen::Provisioner::Ansible::Config.new(provisioner_config)
+        super(config)
       end
 
-      default_config :roles_path do |provisioner|
-         provisioner.calculate_path('roles') or
-          raise 'No roles_path detected. Please specify one in .kitchen.yml'
+      def finalize_config!(instance)
+        config.set_instance(instance)
+        super(instance)
       end
-
-      default_config :group_vars_path do |provisioner|
-         provisioner.calculate_path('group_vars', :directory)
-      end
-
-      default_config :additional_copy_path do |provisioner|
-         provisioner.calculate_path('additional_copy', :directory)
-      end
-
-      default_config :host_vars_path do |provisioner|
-         provisioner.calculate_path('host_vars', :directory)
-      end
-
-      default_config :modules_path do |provisioner|
-         provisioner.calculate_path('modules', :directory)
-      end
-
-      default_config :ansiblefile_path do |provisioner|
-        provisioner.calculate_path('Ansiblefile', :file)
-      end
-
-      default_config :filter_plugins_path do |provisioner|
-         provisioner.calculate_path('filter_plugins', :directory)
-      end
-
-      default_config :ansible_vault_password_file do |provisioner|
-        provisioner.calculate_path('ansible-vault-password', :file)
-      end
-
-      default_config :requirements_path, false
-      default_config :ansible_verbose, false
-      default_config :ansible_verbosity, 1
-      default_config :ansible_check, false
-      default_config :ansible_diff, false
-      default_config :ansible_platform, ''
-      default_config :update_package_repos, true
 
       def verbosity_level(level = 1)
         level = level.to_sym if level.is_a? String
@@ -108,21 +62,6 @@ module Kitchen
           level
         else
           raise 'Invalid ansible_verbosity setting.  Valid values are: 1, 2, 3, 4 OR :info, :warn, :debug, :trace'
-        end
-      end
-
-      def calculate_path(path, type = :directory)
-        base = config[:test_base_path]
-        candidates = []
-        candidates << File.join(base, instance.suite.name, 'ansible', path)
-        candidates << File.join(base, instance.suite.name, path)
-        candidates << File.join(base, path)
-        candidates << File.join(Dir.pwd, path)
-        candidates << File.join(Dir.pwd) if path == 'roles'
-    
-        debug("Calculating path for #{path}, candidates are: #{candidates.to_s}")
-        candidates.find do |c|
-          type == :directory ? File.directory?(c) : File.file?(c)
         end
       end
 

--- a/spec/kitchen/provisioner/ansible/config_spec.rb
+++ b/spec/kitchen/provisioner/ansible/config_spec.rb
@@ -1,8 +1,8 @@
 # -*- encoding: utf-8 -*-
 #
-# Author:: Neill Turner (<neillwturner@gmail.com>)
+# Author:: Michael Heap (<m@michaelheap.com>)
 #
-# Copyright (C) 2013,2014 Neill Turner
+# Copyright (C) 2015 Michael Heap
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/kitchen/provisioner/ansible/config_spec.rb
+++ b/spec/kitchen/provisioner/ansible/config_spec.rb
@@ -1,0 +1,82 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Neill Turner (<neillwturner@gmail.com>)
+#
+# Copyright (C) 2013,2014 Neill Turner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kitchen'
+require 'kitchen/provisioner/ansible/config'
+
+# Work around for lazy loading
+describe Kitchen::Provisioner::Ansible::Config do
+
+  describe "default values" do
+
+    [
+      [:ansible_verbose, false],
+      [:require_ansible_omnibus, false],
+      [:ansible_omnibus_url, nil],
+      [:ansible_omnibus_remote_path, '/opt/ansible'],
+      [:ansible_version, nil],
+      [:require_ansible_repo, true],
+      [:extra_vars, {}],
+      [:tags, []],
+      [:ansible_apt_repo, "ppa:ansible/ansible"],
+      [:ansible_yum_repo, "https://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm"],
+      [:chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"],
+      [:requirements_path, false],
+      [:ansible_verbose, false],
+      [:ansible_verbosity, 1],
+      [:ansible_check, false],
+      [:ansible_diff, false],
+      [:ansible_platform, ''],
+      [:update_package_repos, true]
+    ].each do |item|
+      it "should contain the correct default value for '#{item[0]}'" do
+      c = Kitchen::Provisioner::Ansible::Config.new({})
+        expect(c[item[0]]).to eq item[1]
+      end
+    end
+  end
+
+  describe "set values" do
+
+    [
+      [:ansible_verbose, 4],
+      [:require_ansible_omnibus, true],
+      [:ansible_omnibus_url, 'http://example.com'],
+      [:ansible_omnibus_remote_path, '/tmp/foo'],
+      [:ansible_version, '1.9.2'],
+      [:require_ansible_repo, false],
+      [:extra_vars, {:foo => "bar"}],
+      [:tags, ["one", "two"]],
+      [:ansible_apt_repo, "ppa:demo/ansible"],
+      [:ansible_yum_repo, "https://example.com/ansible.rpm"],
+      [:chef_bootstrap_url, "https://www.example.com/install_chef.sh"],
+      [:requirements_path, "/path/to/req"],
+      [:ansible_verbose, true],
+      [:ansible_verbosity, 8],
+      [:ansible_check, true],
+      [:ansible_diff, true],
+      [:ansible_platform, 'banana'],
+      [:update_package_repos, false]
+    ].each do |item|
+      it "should contain the correct set value for '#{item[0]}'" do
+      c = Kitchen::Provisioner::Ansible::Config.new({item[0] => item[1]})
+        expect(c[item[0]]).to eq item[1]
+      end
+    end
+  end
+end


### PR DESCRIPTION
To reduce how much of a god-like file ansible_playbook.rb is, I'm attempting to split some of the functionality out into their own modules. This PR removes configuration and adds it to it's own class. This should be API compatible with what was previously there.

Tests pass, and I've run a few tests by hand to make sure that the flags are generated correctly still (they are).

If this is accepted, I'm going to look at moving command line flag generation to it's own class too