### PR TITLE
Adding option to install Ansible from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bundle
 vendor
+integration_test/.kitchen/

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-# A sample Gemfile
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ RSpec::Core::RakeTask.new(:test) do |t|
   t.pattern = Dir.glob('spec/**/*_spec.rb')
   t.rspec_opts = '--format documentation'
 end
+
+task :default => :test

--- a/integration_test/.kitchen.yml
+++ b/integration_test/.kitchen.yml
@@ -1,0 +1,30 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: ansible_playbook
+  ansible_verbose: true
+  ansible_verbosity: 3
+  hosts: all
+
+verifier:
+  ruby_bindir: '/usr/bin'
+
+platforms:
+  - name: trusty64
+    driver_config:
+      box: ubuntu/trusty64
+      box_url: https://atlas.hashicorp.com/ubuntu/trusty64
+  - name: centos-6.6
+    driver_config:
+      box: chef/centos-6.6
+      box_url: https://atlas.hashicorp.com/chef/boxes/centos-6.6
+
+suites:
+  - name: default
+  - name: from_source
+    provisioner:
+      require_ansible_repo: false
+      require_ansible_source: true
+      playbook: test/integration/default/default.yml

--- a/integration_test/Gemfile
+++ b/integration_test/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "test-kitchen"
+gem "kitchen-ansible", :path => "../"
+gem "kitchen-vagrant"
+gem "serverspec"

--- a/integration_test/Gemfile.lock
+++ b/integration_test/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: ../
+  specs:
+    kitchen-ansible (0.0.17)
+      librarian-ansible
+      test-kitchen
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    highline (1.7.2)
+    kitchen-vagrant (0.18.0)
+      test-kitchen (~> 1.4)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-ansible (1.0.6)
+      faraday
+      librarian (~> 0.1.0)
+    mixlib-shellout (2.1.0)
+    multi_json (1.11.1)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.1)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.3.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
+    safe_yaml (1.0.4)
+    serverspec (2.18.0)
+      multi_json
+      rspec (~> 3.0)
+      rspec-its
+      specinfra (~> 2.35)
+    specinfra (2.36.0)
+      net-scp
+      net-ssh
+    test-kitchen (1.4.1)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (~> 2.7)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kitchen-ansible!
+  kitchen-vagrant
+  serverspec
+  test-kitchen

--- a/integration_test/test/integration/default/default.yml
+++ b/integration_test/test/integration/default/default.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: localhost
+
+  tasks:
+    - name: echo
+      command: echo 'Hello World'

--- a/integration_test/test/integration/default/serverspec/sample_spec.rb
+++ b/integration_test/test/integration/default/serverspec/sample_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe "Nothing" do
+  describe file('/tmp') do
+    it { should be_directory }
+  end
+end

--- a/integration_test/test/integration/default/serverspec/spec_helper.rb
+++ b/integration_test/test/integration/default/serverspec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'serverspec'
+set :backend, :exec

--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -52,6 +52,7 @@ module Kitchen
         default_config :ansible_diff, false
         default_config :ansible_platform, ''
         default_config :update_package_repos, true
+        default_config :require_ansible_source, false
 
         default_config :playbook do |provisioner|
           provisioner.calculate_path('default.yml', :file) or

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -66,124 +66,42 @@ module Kitchen
       end
 
       def install_command
-        return unless config[:require_ansible_omnibus] or config[:require_ansible_repo]
         if config[:require_ansible_omnibus]
-          info("Installing ansible using ansible omnibus")
-          version = if !config[:ansible_version].nil?
-            "-v #{config[:ansible_version]}"
-          else
-            ""
-          end
-          <<-INSTALL
-          #{Util.shell_helpers}
-
-          if [ ! -d "#{config[:ansible_omnibus_remote_path]}" ]; then
-            echo "-----> Installing Ansible Omnibus"
-            do_download #{config[:ansible_omnibus_url]} /tmp/ansible_install.sh
-            #{sudo('sh')} /tmp/ansible_install.sh #{version}
-          fi
-          #{install_busser_prereqs}
-          INSTALL
-        else
+          cmd = install_omnibus_command
+        elsif config[:require_ansible_repo]
           case ansible_platform
           when "debian", "ubuntu"
-          info("Installing ansible on #{ansible_platform}")
-          <<-INSTALL
-          if [ ! $(which ansible) ]; then
-           #{update_packages_debian_cmd}
-            ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
-            #{sudo('apt-get')} -y install apt-utils git
-            ## Fix debconf tty warning messages
-            export DEBIAN_FRONTEND=noninteractive
-            ## 13.10, 14.04 include add-apt-repository in software-properties-common
-            #{sudo('apt-get')} -y install software-properties-common
-            ## 10.04, 12.04 include add-apt-repository in
-            #{sudo('apt-get')} -y install python-software-properties
-          #  #{sudo('wget')} #{ansible_apt_repo}
-          #  #{sudo('dpkg')} -i #{ansible_apt_repo_file}
-          #  #{sudo('apt-get')} -y autoremove ## These autoremove/autoclean are sometimes useful but
-          #  #{sudo('apt-get')} -y autoclean  ## don't seem necessary for the Ubuntu OpsCode bento boxes that are not EOL by Canonical
-          #  #{sudo('apt-get')} -y --force-yes install ansible#{ansible_debian_version} python-selinux
-            ## 10.04 version of add-apt-repository doesn't accept --yes
-            ## later versions require interaction from user, so we must specify --yes
-            ## First try with -y flag, else if it fails, try without.
-            ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
-            #{sudo('add-apt-repository')} -y #{ansible_apt_repo} || #{sudo('add-apt-repository')} #{ansible_apt_repo}
-            #{sudo('apt-get')} update
-            #{sudo('apt-get')} -y install ansible
-            ## This test works on ubuntu to test if ansible repo has been installed via rquillo ppa repo
-            ## if [ $(apt-cache madison ansible | grep -c rquillo ) -gt 0 ]; then echo 'success'; else echo 'fail'; fi
-          fi
-          #{install_busser_prereqs}
-          INSTALL
+            info("Installing ansible on #{ansible_platform}")
+            cmd = install_debian_command
           when "redhat", "centos", "fedora"
-          info("Installing ansible on #{ansible_platform}")
-          <<-INSTALL
-          if [ ! $(which ansible) ]; then
-            #{sudo('rpm')} -ivh #{ansible_yum_repo}
-            #{update_packages_redhat_cmd}
-            #{sudo('yum')} -y install ansible#{ansible_redhat_version} libselinux-python git
-          fi
-          #{install_busser_prereqs}
-          INSTALL
+            info("Installing ansible on #{ansible_platform}")
+            cmd = install_redhat_command
           when "amazon"
-          info("Installing ansible on #{ansible_platform}")
-          <<-INSTALL
-          if [ ! $(which ansible) ]; then
-            #{sudo('yum-config-manager')} --enable epel/x86_64
-	    #{sudo('yum')} -y install ansible#{ansible_redhat_version} git
-            #{sudo('alternatives')} --set python /usr/bin/python2.6
-            #{sudo('yum')} clean all
-            #{sudo('yum')} install yum-python26 -y
-          fi
-          #{install_busser_prereqs}
-          INSTALL
-         else
-          info("Installing ansible, will try to determine platform os")
-          <<-INSTALL
-          if [ ! $(which ansible) ]; then
-            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
-            if ! [ grep -q 'Amazon Linux' /etc/system-release ]; then
-               #{sudo('rpm')} -ivh #{ansible_yum_repo}
-               #{update_packages_redhat_cmd}
-               #{sudo('yum')} -y install ansible#{ansible_redhat_version} libselinux-python git
-            else
-               #{sudo('yum-config-manager')} --enable epel/x86_64
-	       #{sudo('yum')} -y install ansible#{ansible_redhat_version} git
-               #{sudo('alternatives')} --set python /usr/bin/python2.6
-               #{sudo('yum')} clean all
-               #{sudo('yum')} install yum-python26 -y               
+            info("Installing ansible on #{ansible_platform}")
+            cmd = install_amazon_linux_command
+          else
+            info("Installing ansible, will try to determine platform os")
+            cmd = <<-INSTALL
+            if [ ! $(which ansible) ]; then
+              if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
+                if ! [ grep -q 'Amazon Linux' /etc/system-release ]; then
+                  #{install_redhat_command}
+                else
+                  #{install_amazon_linux_command}
+                fi
+              else
+                #{install_debian_command}
+              fi
             fi
-            else
-           #{update_packages_debian_cmd}
-           ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
-            #{sudo('apt-get')} -y install apt-utils git
-            ## Fix debconf tty warning messages
-            export DEBIAN_FRONTEND=noninteractive
-            ## 13.10, 14.04 include add-apt-repository in software-properties-common
-            #{sudo('apt-get')} -y install software-properties-common
-            ## 10.04, 12.04 include add-apt-repository in
-            #{sudo('apt-get')} -y install python-software-properties
-          #  #{sudo('wget')} #{ansible_apt_repo}
-          #  #{sudo('dpkg')} -i #{ansible_apt_repo_file}
-          #  #{sudo('apt-get')} -y autoremove ## These autoremove/autoclean are sometimes useful but
-          #  #{sudo('apt-get')} -y autoclean  ## don't seem necessary for the Ubuntu OpsCode bento boxes that are not EOL by Canonical
-          #  #{sudo('apt-get')} -y --force-yes install ansible#{ansible_debian_version} python-selinux
-            ## 10.04 version of add-apt-repository doesn't accept --yes
-            ## later versions require interaction from user, so we must specify --yes
-            ## First try with -y flag, else if it fails, try without.
-            ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
-            #{sudo('add-apt-repository')} -y #{ansible_apt_repo} || #{sudo('add-apt-repository')} #{ansible_apt_repo}
-            #{sudo('apt-get')} update
-            #{sudo('apt-get')} -y install ansible
-            ## This test works on ubuntu to test if ansible repo has been installed via rquillo ppa repo
-            ## if [ $(apt-cache madison ansible | grep -c rquillo ) -gt 0 ]; then echo 'success'; else echo 'fail'; fi
-            fi
-          fi
-          #{install_busser_prereqs}
-          INSTALL
-         end
+            INSTALL
+          end
+        elsif config[:require_ansible_source]
+          info("Installing ansible from source")
+          cmd = install_ansible_from_source_command
+        else
+          return
         end
+        cmd + install_busser_prereqs
       end
 
       def install_busser_prereqs
@@ -250,408 +168,506 @@ module Kitchen
         install
       end
 
-        def init_command
-          dirs = %w{modules roles group_vars host_vars}.
-            map { |dir| File.join(config[:root_path], dir) }.join(" ")
-          cmd = "#{sudo('rm')} -rf #{dirs};"
-          cmd = cmd+" mkdir -p #{config[:root_path]}"
-          debug(cmd)
-          cmd
-        end
+      def init_command
+        dirs = %w{modules roles group_vars host_vars}.
+          map { |dir| File.join(config[:root_path], dir) }.join(" ")
+        cmd = "#{sudo('rm')} -rf #{dirs};"
+        cmd = cmd+" mkdir -p #{config[:root_path]}"
+        debug(cmd)
+        cmd
+      end
 
-        def create_sandbox
-          super
-          debug("Creating local sandbox in #{sandbox_path}")
+      def create_sandbox
+        super
+        debug("Creating local sandbox in #{sandbox_path}")
 
-          yield if block_given?
+        yield if block_given?
 
-          prepare_playbook
-          prepare_modules
-          prepare_roles
-          prepare_ansible_cfg
-          prepare_group_vars
-          prepare_additional_copy_path
-          prepare_host_vars
-          prepare_hosts
-          prepare_filter_plugins
-          prepare_ansible_vault_password_file
-          info('Finished Preparing files for transfer')
+        prepare_playbook
+        prepare_modules
+        prepare_roles
+        prepare_ansible_cfg
+        prepare_group_vars
+        prepare_additional_copy_path
+        prepare_host_vars
+        prepare_hosts
+        prepare_filter_plugins
+        prepare_ansible_vault_password_file
+        info('Finished Preparing files for transfer')
 
-        end
+      end
 
-        def cleanup_sandbox
-          return if sandbox_path.nil?
-          debug("Cleaning up local sandbox in #{sandbox_path}")
-          FileUtils.rmtree(sandbox_path)
-        end
+      def cleanup_sandbox
+        return if sandbox_path.nil?
+        debug("Cleaning up local sandbox in #{sandbox_path}")
+        FileUtils.rmtree(sandbox_path)
+      end
 
-        def prepare_command
-          commands = []
+      def prepare_command
+        commands = []
 
-          # Prevent failure when ansible package installation doesn't contain /etc/ansible
+        # Prevent failure when ansible package installation doesn't contain /etc/ansible
+        commands << [
+            sudo("bash -c '[ -d /etc/ansible ] || mkdir /etc/ansible'")
+        ]
+
+        commands << [
+            sudo('cp'),File.join(config[:root_path], 'ansible.cfg'),'/etc/ansible',
+        ].join(' ')
+
+        commands << [
+            sudo('cp -r'), File.join(config[:root_path],'group_vars'), '/etc/ansible/.',
+        ].join(' ')
+
+        commands << [
+            sudo('cp -r'), File.join(config[:root_path],'host_vars'), '/etc/ansible/.',
+        ].join(' ')
+
+        if galaxy_requirements
+          if config[:require_ansible_source]
+            commands << setup_ansible_env_from_source
+          end
           commands << [
-              sudo("bash -c '[ -d /etc/ansible ] || mkdir /etc/ansible'")
-          ]
-
-          commands << [
-              sudo('cp'),File.join(config[:root_path], 'ansible.cfg'),'/etc/ansible',
+             'ansible-galaxy', 'install', '--force',
+             '-p', File.join(config[:root_path], 'roles'),
+             '-r', File.join(config[:root_path], galaxy_requirements),
           ].join(' ')
-
-          commands << [
-              sudo('cp -r'), File.join(config[:root_path],'group_vars'), '/etc/ansible/.',
-          ].join(' ')
-
-          commands << [
-              sudo('cp -r'), File.join(config[:root_path],'host_vars'), '/etc/ansible/.',
-          ].join(' ')
-
-          if galaxy_requirements
-            commands << [
-               'ansible-galaxy', 'install', '--force',
-               '-p', File.join(config[:root_path], 'roles'),
-               '-r', File.join(config[:root_path], galaxy_requirements),
-            ].join(' ')
-          end
-
-          command = commands.join(' && ')
-          debug(command)
-          command
         end
 
-        def run_command
-          [
-            sudo("ansible-playbook"),
-            "-i #{File.join(config[:root_path], 'hosts')}",
-            "-M #{File.join(config[:root_path], 'modules')}",
-            ansible_verbose_flag,
-            ansible_check_flag,
-            ansible_diff_flag,
-            ansible_vault_flag,
-            extra_vars,
-            tags,
-            "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
-          ].join(" ")
+        command = commands.join(' && ')
+        debug(command)
+        command
+      end
+
+      def run_command
+        if config[:require_ansible_source]
+          cmd = "#{setup_ansible_env_from_source} && ansible-playbook"
+        else
+          cmd = sudo("ansible-playbook")
         end
+        [
+          cmd,
+          "-i #{File.join(config[:root_path], 'hosts')}",
+          "-M #{File.join(config[:root_path], 'modules')}",
+          ansible_verbose_flag,
+          ansible_check_flag,
+          ansible_diff_flag,
+          ansible_vault_flag,
+          extra_vars,
+          tags,
+          "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
+        ].join(" ")
+      end
 
-        protected
+      protected
 
-        def load_needed_dependencies!
-          if File.exists?(ansiblefile)
-            debug("Ansiblefile found at #{ansiblefile}, loading Librarian-Ansible")
-            Ansible::Librarian.load!(logger)
-          end
+      def load_needed_dependencies!
+        if File.exists?(ansiblefile)
+          debug("Ansiblefile found at #{ansiblefile}, loading Librarian-Ansible")
+          Ansible::Librarian.load!(logger)
         end
+      end
 
-        def tmp_modules_dir
-          File.join(sandbox_path, 'modules')
-        end
-
-        def tmp_playbook_path
-          File.join(sandbox_path, File.basename(playbook))
-        end
-
-        def tmp_host_vars_dir
-          File.join(sandbox_path, 'host_vars')
-        end
-
-        def tmp_roles_dir
-          File.join(sandbox_path, 'roles')
-        end
-
-        def tmp_filter_plugins_dir
-          File.join(sandbox_path, 'filter_plugins')
-        end
-
-        def tmp_ansible_vault_password_file_path
-          File.join(sandbox_path, File.basename(ansible_vault_password_file))
-        end
-
-        def ansiblefile
-          config[:ansiblefile_path] || ''
-        end
-
-        def galaxy_requirements
-          config[:requirements_path] || nil
-        end
-
-        def playbook
-          config[:playbook]
-        end
-
-        def hosts
-          config[:hosts]
-        end
-
-        def roles
-          config[:roles_path]
-        end
-
-        def role_name
-          File.basename(roles) == 'roles' ? '' : File.basename(roles)
-        end
-
-        def modules
-          config[:modules_path]
-        end
-
-        def group_vars
-          config[:group_vars_path].to_s
-        end
-
-        def additional_copy
-          config[:additional_copy_path]
-        end
-
-        def host_vars
-          config[:host_vars_path].to_s
-        end
-
-        def filter_plugins
-          config[:filter_plugins_path].to_s
-        end
-
-        def ansible_vault_password_file
-          config[:ansible_vault_password_file]
-        end
-
-        def ansible_debian_version
-          config[:ansible_version] ? "=#{config[:ansible_version]}" : nil
-        end
-
-        def ansible_redhat_version
-          config[:ansible_version] ? "-#{config[:ansible_version]}" : nil
-        end
-
-        def ansible_verbose_flag
-          config[:ansible_verbose] ? '-' << ('v' * verbosity_level(config[:ansible_verbosity])) : nil
-        end
-
-        def ansible_check_flag
-          config[:ansible_check] ? '--check' : nil
-        end
-
-        def ansible_diff_flag
-          config[:ansible_diff] ? '--diff' : nil
-        end
-
-        def ansible_vault_flag
-          debug(config[:ansible_vault_password_file])
-          config[:ansible_vault_password_file] ? "--vault-password-file=#{File.join(config[:root_path], File.basename(config[:ansible_vault_password_file]))}" : nil
-        end
-
-        def ansible_platform
-          config[:ansible_platform].to_s.downcase
-        end
-
-        def update_packages_debian_cmd
-          config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil
-        end
-
-        def update_packages_redhat_cmd
-          config[:update_package_repos] ? "#{sudo('yum')} makecache" : nil
-        end
-
-        def extra_vars
-          bash_vars = config[:extra_vars]
-          if config.key?(:attributes) && config[:attributes].key?(:extra_vars) && config[:attributes][:extra_vars].is_a?(Hash)
-            bash_vars = config[:attributes][:extra_vars]
-          end
-
-          return nil if bash_vars.none?
-          bash_vars = JSON.dump(bash_vars)
-          bash_vars = "-e '#{bash_vars}'"
-          debug(bash_vars)
-          bash_vars
-        end
-
-        def tags
-          bash_tags = config.key?(:attributes) && config[:attributes].key?(:tags) && config[:attributes][:tags].is_a?(Array) ? config[:attributes][:tags] : config[:tags]
-          return nil if bash_tags.empty?
-
-          bash_tags = bash_tags.join(",")
-          bash_tags = "-t '#{bash_tags}'"
-          debug(bash_tags)
-          bash_tags
-        end
-
-        def ansible_apt_repo
-          config[:ansible_apt_repo]
-        end
-
-        def ansible_apt_repo_file
-          config[:ansible_apt_repo].split('/').last
-        end
-
-        def ansible_yum_repo
-          config[:ansible_yum_repo]
-        end
-
-        def chef_url
-          config[:chef_bootstrap_url]
-        end
-        
-        def require_ruby_for_busser
-          config[:require_ruby_for_busser]
-        end 
-        
-        def require_chef_for_busser
-          config[:require_chef_for_busser]
-        end
-        
-        def prepare_roles
-          info('Preparing roles')
-          debug("Using roles from #{roles}")
-
-          resolve_with_librarian if File.exists?(ansiblefile)
-
-          if galaxy_requirements
-            FileUtils.cp(galaxy_requirements, File.join(sandbox_path, galaxy_requirements))
-          end
-
-          # Detect whether we are running tests on a role
-          # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
-
-          FileUtils.mkdir_p(File.join(tmp_roles_dir, role_name))
-          FileUtils.cp_r(Dir.glob("#{roles}/*"), File.join(tmp_roles_dir, role_name))
-        end
-
-        # /etc/ansible/ansible.cfg should contain
-        # roles_path = /tmp/kitchen/roles
-        def prepare_ansible_cfg
-          info('Preparing ansible.cfg file')
-          ansible_config_file = "#{File.join(sandbox_path, 'ansible.cfg')}"
-
-          roles_paths = []
-          roles_paths << File.join(config[:root_path], 'roles') unless config[:roles_path].nil?
-          additional_files.each do |additional_file|
-            roles_paths << File.join(config[:root_path], File.basename(additional_file))
-          end
-
-          if roles_paths.empty?
-            info('No roles have been set. empty ansible.cfg generated')
-            File.open(ansible_config_file, "wb") do |file|
-               file.write("#no roles path specified\n")
-            end
+      def install_ansible_from_source_command
+        <<-INSTALL
+        if [ ! -d #{config[:root_path]}/ansible ]; then
+          if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
+            #{update_packages_redhat_cmd}
+            #{sudo('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev
           else
-            debug("Setting roles_path inside VM to #{ roles_paths.join(':') }")
-            File.open( ansible_config_file, "wb") do |file|
-               file.write("[defaults]\nroles_path = #{ roles_paths.join(':') }\n")
-            end
-          end
+            #{update_packages_debian_cmd}
+            #{sudo('apt-get')} -y install git python python-setuptools
+          fi
+
+          git clone git://github.com/ansible/ansible.git --recursive #{config[:root_path]}/ansible
+          #{sudo('easy_install')} pip
+          sudo -EH 'pip' install paramiko PyYAML Jinja2 httplib2
+        fi
+        INSTALL
+      end
+
+      def install_omnibus_command
+        info("Installing ansible using ansible omnibus")
+        version = if !config[:ansible_version].nil?
+          "-v #{config[:ansible_version]}"
+        else
+          ""
+        end
+        <<-INSTALL
+        #{Util.shell_helpers}
+
+        if [ ! -d "#{config[:ansible_omnibus_remote_path]}" ]; then
+          echo "-----> Installing Ansible Omnibus"
+          do_download #{config[:ansible_omnibus_url]} /tmp/ansible_install.sh
+          #{sudo('sh')} /tmp/ansible_install.sh #{version}
+        fi
+        INSTALL
+      end
+
+      def install_debian_command
+        <<-INSTALL
+        if [ ! $(which ansible) ]; then
+          #{update_packages_debian_cmd}
+
+          ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
+          #{sudo('apt-get')} -y install apt-utils git
+
+          ## Fix debconf tty warning messages
+          export DEBIAN_FRONTEND=noninteractive
+
+          ## 13.10, 14.04 include add-apt-repository in software-properties-common
+          #{sudo('apt-get')} -y install software-properties-common
+
+          ## 10.04, 12.04 include add-apt-repository in
+          #{sudo('apt-get')} -y install python-software-properties
+
+          ## 10.04 version of add-apt-repository doesn't accept --yes
+          ## later versions require interaction from user, so we must specify --yes
+          ## First try with -y flag, else if it fails, try without.
+          ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
+          #{sudo('add-apt-repository')} -y #{ansible_apt_repo} || #{sudo('add-apt-repository')} #{ansible_apt_repo}
+          #{sudo('apt-get')} update
+          #{sudo('apt-get')} -y install ansible
+        fi
+        INSTALL
+      end
+
+      def install_redhat_command
+        <<-INSTALL
+        if [ ! $(which ansible) ]; then
+          #{sudo('rpm')} -ivh #{ansible_yum_repo}
+          #{update_packages_redhat_cmd}
+          #{sudo('yum')} -y install ansible#{ansible_redhat_version} libselinux-python git
+        fi
+        INSTALL
+      end
+
+      def install_amazon_linux_command
+        <<-INSTALL
+        if [ ! $(which ansible) ]; then
+          #{sudo('yum-config-manager')} --enable epel/x86_64
+          #{sudo('yum')} -y install ansible#{ansible_redhat_version} git
+          #{sudo('alternatives')} --set python /usr/bin/python2.6
+          #{sudo('yum')} clean all
+          #{sudo('yum')} install yum-python26 -y
+        fi
+        INSTALL
+      end
+
+      def setup_ansible_env_from_source
+        "cd #{config[:root_path]}/ansible && source hacking/env-setup && cd ../"
+      end
+
+      def tmp_modules_dir
+        File.join(sandbox_path, 'modules')
+      end
+
+      def tmp_playbook_path
+        File.join(sandbox_path, File.basename(playbook))
+      end
+
+      def tmp_host_vars_dir
+        File.join(sandbox_path, 'host_vars')
+      end
+
+      def tmp_roles_dir
+        File.join(sandbox_path, 'roles')
+      end
+
+      def tmp_filter_plugins_dir
+        File.join(sandbox_path, 'filter_plugins')
+      end
+
+      def tmp_ansible_vault_password_file_path
+        File.join(sandbox_path, File.basename(ansible_vault_password_file))
+      end
+
+      def ansiblefile
+        config[:ansiblefile_path] || ''
+      end
+
+      def galaxy_requirements
+        config[:requirements_path] || nil
+      end
+
+      def playbook
+        config[:playbook]
+      end
+
+      def hosts
+        config[:hosts]
+      end
+
+      def roles
+        config[:roles_path]
+      end
+
+      def role_name
+        File.basename(roles) == 'roles' ? '' : File.basename(roles)
+      end
+
+      def modules
+        config[:modules_path]
+      end
+
+      def group_vars
+        config[:group_vars_path].to_s
+      end
+
+      def additional_copy
+        config[:additional_copy_path]
+      end
+
+      def host_vars
+        config[:host_vars_path].to_s
+      end
+
+      def filter_plugins
+        config[:filter_plugins_path].to_s
+      end
+
+      def ansible_vault_password_file
+        config[:ansible_vault_password_file]
+      end
+
+      def ansible_debian_version
+        config[:ansible_version] ? "=#{config[:ansible_version]}" : nil
+      end
+
+      def ansible_redhat_version
+        config[:ansible_version] ? "-#{config[:ansible_version]}" : nil
+      end
+
+      def ansible_verbose_flag
+        config[:ansible_verbose] ? '-' << ('v' * verbosity_level(config[:ansible_verbosity])) : nil
+      end
+
+      def ansible_check_flag
+        config[:ansible_check] ? '--check' : nil
+      end
+
+      def ansible_diff_flag
+        config[:ansible_diff] ? '--diff' : nil
+      end
+
+      def ansible_vault_flag
+        debug(config[:ansible_vault_password_file])
+        config[:ansible_vault_password_file] ? "--vault-password-file=#{File.join(config[:root_path], File.basename(config[:ansible_vault_password_file]))}" : nil
+      end
+
+      def ansible_platform
+        config[:ansible_platform].to_s.downcase
+      end
+
+      def update_packages_debian_cmd
+        config[:update_package_repos] ? "#{sudo('apt-get')} update" : nil
+      end
+
+      def update_packages_redhat_cmd
+        config[:update_package_repos] ? "#{sudo('yum')} makecache" : nil
+      end
+
+      def extra_vars
+        bash_vars = config[:extra_vars]
+        if config.key?(:attributes) && config[:attributes].key?(:extra_vars) && config[:attributes][:extra_vars].is_a?(Hash)
+          bash_vars = config[:attributes][:extra_vars]
         end
 
+        return nil if bash_vars.none?
+        bash_vars = JSON.dump(bash_vars)
+        bash_vars = "-e '#{bash_vars}'"
+        debug(bash_vars)
+        bash_vars
+      end
 
-        # localhost ansible_connection=local
-        # [example_servers]
-        # localhost
-        def prepare_hosts
-          info('Preparing hosts file')
+      def tags
+        bash_tags = config.key?(:attributes) && config[:attributes].key?(:tags) && config[:attributes][:tags].is_a?(Array) ? config[:attributes][:tags] : config[:tags]
+        return nil if bash_tags.empty?
 
-          if config[:hosts].nil?
-            raise 'No hosts have been set. Please specify one in .kitchen.yml'
+        bash_tags = bash_tags.join(",")
+        bash_tags = "-t '#{bash_tags}'"
+        debug(bash_tags)
+        bash_tags
+      end
+
+      def ansible_apt_repo
+        config[:ansible_apt_repo]
+      end
+
+      def ansible_apt_repo_file
+        config[:ansible_apt_repo].split('/').last
+      end
+
+      def ansible_yum_repo
+        config[:ansible_yum_repo]
+      end
+
+      def chef_url
+        config[:chef_bootstrap_url]
+      end
+
+      def require_ruby_for_busser
+        config[:require_ruby_for_busser]
+      end 
+
+      def require_chef_for_busser
+        config[:require_chef_for_busser]
+      end
+
+      def prepare_roles
+        info('Preparing roles')
+        debug("Using roles from #{roles}")
+
+        resolve_with_librarian if File.exists?(ansiblefile)
+
+        if galaxy_requirements
+          FileUtils.cp(galaxy_requirements, File.join(sandbox_path, galaxy_requirements))
+        end
+
+        # Detect whether we are running tests on a role
+        # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
+
+        FileUtils.mkdir_p(File.join(tmp_roles_dir, role_name))
+        FileUtils.cp_r(Dir.glob("#{roles}/*"), File.join(tmp_roles_dir, role_name))
+      end
+
+      # /etc/ansible/ansible.cfg should contain
+      # roles_path = /tmp/kitchen/roles
+      def prepare_ansible_cfg
+        info('Preparing ansible.cfg file')
+        ansible_config_file = "#{File.join(sandbox_path, 'ansible.cfg')}"
+
+        roles_paths = []
+        roles_paths << File.join(config[:root_path], 'roles') unless config[:roles_path].nil?
+        additional_files.each do |additional_file|
+          roles_paths << File.join(config[:root_path], File.basename(additional_file))
+        end
+
+        if roles_paths.empty?
+          info('No roles have been set. empty ansible.cfg generated')
+          File.open(ansible_config_file, "wb") do |file|
+             file.write("#no roles path specified\n")
+          end
+        else
+          debug("Setting roles_path inside VM to #{ roles_paths.join(':') }")
+          File.open( ansible_config_file, "wb") do |file|
+             file.write("[defaults]\nroles_path = #{ roles_paths.join(':') }\n")
+          end
+        end
+      end
+
+
+      # localhost ansible_connection=local
+      # [example_servers]
+      # localhost
+      def prepare_hosts
+        info('Preparing hosts file')
+
+        if config[:hosts].nil?
+          raise 'No hosts have been set. Please specify one in .kitchen.yml'
+        else
+          debug("Using host from #{hosts}")
+          File.open(File.join(sandbox_path, "hosts"), "wb") do |file|
+             file.write("localhost ansible_connection=local\n[#{hosts}]\nlocalhost\n")
+          end
+        end
+      end
+
+      def prepare_playbook
+        info('Preparing playbook')
+        debug("Copying playbook from #{playbook} to #{tmp_playbook_path}")
+        FileUtils.cp_r(playbook, tmp_playbook_path)
+      end
+
+
+      def prepare_group_vars
+        info('Preparing group_vars')
+        tmp_group_vars_dir = File.join(sandbox_path, 'group_vars')
+        FileUtils.mkdir_p(tmp_group_vars_dir)
+
+        unless File.directory?(group_vars)
+          info 'nothing to do for group_vars'
+          return
+        end
+
+        debug("Using group_vars from #{group_vars}")
+        FileUtils.cp_r(Dir.glob("#{group_vars}/*"), tmp_group_vars_dir)
+      end
+
+      def prepare_additional_copy_path
+        info('Preparing additional_copy_path')
+        additional_files.each do |file|
+          destination = File.join(sandbox_path, File.basename(file))
+          if File.directory?(file)
+            info("Copy dir: #{file} #{destination}")
+            FileUtils.cp_r(file, destination)
           else
-            debug("Using host from #{hosts}")
-            File.open(File.join(sandbox_path, "hosts"), "wb") do |file|
-               file.write("localhost ansible_connection=local\n[#{hosts}]\nlocalhost\n")
-            end
+            info("Copy file: #{file} #{destination}")
+            FileUtils.cp file, destination
           end
         end
+      end
 
-        def prepare_playbook
-          info('Preparing playbook')
-          debug("Copying playbook from #{playbook} to #{tmp_playbook_path}")
-          FileUtils.cp_r(playbook, tmp_playbook_path)
+      def additional_files
+        additional_files = []
+        if ( additional_copy )
+          additional_files = additional_copy.kind_of?(Array) ? additional_copy : [additional_copy]
+        end
+        additional_files.map { |additional_dir | additional_dir.to_s }
+      end
+
+      def prepare_host_vars
+        info('Preparing host_vars')
+        FileUtils.mkdir_p(tmp_host_vars_dir)
+
+        unless File.directory?(host_vars)
+          info 'nothing to do for host_vars'
+          return
         end
 
+        debug("Using host_vars from #{host_vars}")
+        FileUtils.cp_r(Dir.glob("#{host_vars}/*"), tmp_host_vars_dir)
+      end
 
-        def prepare_group_vars
-          info('Preparing group_vars')
-          tmp_group_vars_dir = File.join(sandbox_path, 'group_vars')
-          FileUtils.mkdir_p(tmp_group_vars_dir)
+      def prepare_modules
+        info('Preparing modules')
 
-          unless File.directory?(group_vars)
-            info 'nothing to do for group_vars'
-            return
-          end
+        FileUtils.mkdir_p(tmp_modules_dir)
 
-          debug("Using group_vars from #{group_vars}")
-          FileUtils.cp_r(Dir.glob("#{group_vars}/*"), tmp_group_vars_dir)
+        if modules && File.directory?(modules)
+          debug("Using modules from #{modules}")
+          FileUtils.cp_r(Dir.glob("#{modules}/*"), tmp_modules_dir, remove_destination: true)
+        else
+          info 'nothing to do for modules'
         end
+      end
 
-        def prepare_additional_copy_path
-          info('Preparing additional_copy_path')
-          additional_files.each do |file|
-            destination = File.join(sandbox_path, File.basename(file))
-            if File.directory?(file)
-              info("Copy dir: #{file} #{destination}")
-              FileUtils.cp_r(file, destination)
-            else
-              info("Copy file: #{file} #{destination}")
-              FileUtils.cp file, destination
-            end
-          end
+      def prepare_filter_plugins
+        info('Preparing filter_plugins')
+        FileUtils.mkdir_p(tmp_filter_plugins_dir)
+
+        if filter_plugins && File.directory?(filter_plugins)
+          debug("Using filter_plugins from #{filter_plugins}")
+          FileUtils.cp_r(Dir.glob("#{filter_plugins}/*.py"), tmp_filter_plugins_dir, remove_destination: true)
+        else
+          info 'nothing to do for filter_plugins'
         end
+      end
 
-        def additional_files
-          additional_files = []
-          if ( additional_copy )
-            additional_files = additional_copy.kind_of?(Array) ? additional_copy : [additional_copy]
-          end
-          additional_files.map { |additional_dir | additional_dir.to_s }
+      def prepare_ansible_vault_password_file
+        if ansible_vault_password_file
+          info('Preparing ansible vault password')
+          debug("Copying ansible vault password file from #{ansible_vault_password_file} to #{tmp_ansible_vault_password_file_path}")
+
+          FileUtils.cp(ansible_vault_password_file, tmp_ansible_vault_password_file_path)
         end
+      end
 
-        def prepare_host_vars
-          info('Preparing host_vars')
-          FileUtils.mkdir_p(tmp_host_vars_dir)
-
-          unless File.directory?(host_vars)
-            info 'nothing to do for host_vars'
-            return
-          end
-
-          debug("Using host_vars from #{host_vars}")
-          FileUtils.cp_r(Dir.glob("#{host_vars}/*"), tmp_host_vars_dir)
+      def resolve_with_librarian
+        Kitchen.mutex.synchronize do
+          Ansible::Librarian.new(ansiblefile, tmp_roles_dir, logger).resolve
         end
-
-        def prepare_modules
-          info('Preparing modules')
-
-          FileUtils.mkdir_p(tmp_modules_dir)
-
-          if modules && File.directory?(modules)
-            debug("Using modules from #{modules}")
-            FileUtils.cp_r(Dir.glob("#{modules}/*"), tmp_modules_dir, remove_destination: true)
-          else
-            info 'nothing to do for modules'
-          end
-        end
-
-        def prepare_filter_plugins
-          info('Preparing filter_plugins')
-          FileUtils.mkdir_p(tmp_filter_plugins_dir)
-
-          if filter_plugins && File.directory?(filter_plugins)
-            debug("Using filter_plugins from #{filter_plugins}")
-            FileUtils.cp_r(Dir.glob("#{filter_plugins}/*.py"), tmp_filter_plugins_dir, remove_destination: true)
-          else
-            info 'nothing to do for filter_plugins'
-          end
-        end
-
-        def prepare_ansible_vault_password_file
-          if ansible_vault_password_file
-            info('Preparing ansible vault password')
-            debug("Copying ansible vault password file from #{ansible_vault_password_file} to #{tmp_ansible_vault_password_file_path}")
-
-            FileUtils.cp(ansible_vault_password_file, tmp_ansible_vault_password_file_path)
-          end
-        end
-
-        def resolve_with_librarian
-          Kitchen.mutex.synchronize do
-            Ansible::Librarian.new(ansiblefile, tmp_roles_dir, logger).resolve
-          end
-        end
+      end
     end
   end
 end

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -30,6 +30,7 @@ ansible_omnibus_url | | omnibus ansible install location.
 ansible_omnibus_remote_path | "/opt/ansible" | Server Installation location of an omnibus ansible install.
 require_chef_for_busser|false|install chef to run busser for tests. NOTE: kitchen 1.4 only requires ruby to run busser so this is not required. 
 chef_bootstrap_url |https://www.getchef.com /chef/install.sh| the chef install
+require_ansible_source | false | Install Ansible from source using method described here: http://docs.ansible.com/intro_installation.html#running-from-source. Only works on Debian/Ubuntu at present.
 
 ## Configuring Provisioner Options
 


### PR DESCRIPTION
I ended up needing to test some roles against Ansible functionality that has yet to be released. This required running against the master branch of https://github.com/ansible/ansible as described here: https://docs.ansible.com/intro_installation.html#running-from-source

This change includes an integration test suite that specifically tests the Ansible and Ruby installation on both Trusty and CentOS 6.6 using the package install default method, as well as using the new method of installing Ansible from source.

At present, this feature has only been tested successfully on Ubuntu Trusty. I'm leaving in my attempt at getting CentOS running in case someone who uses it wishes to get it running there as well.