### PR TITLE
Experiment: Add playbooks as a path.

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -59,6 +59,10 @@ module Kitchen
             raise "No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default wrapper playbook for your role in test/integration/playbooks/default.yml or test/integration/default.yml"
         end
 
+        default_config :playbook_path do |provisioner|
+          provisioner.calculate_path('playbook_path', :directory)
+        end
+
         default_config :roles_path do |provisioner|
           provisioner.calculate_path('roles') or
             raise 'No roles_path detected. Please specify one in .kitchen.yml'

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -255,7 +255,7 @@ module Kitchen
           ansible_vault_flag,
           extra_vars,
           tags,
-          "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
+          "#{File.join(tmp_playbook_path, File.basename(config[:playbook]))}",
         ].join(" ")
       end
 
@@ -363,7 +363,11 @@ module Kitchen
       end
 
       def tmp_playbook_path
-        File.join(sandbox_path, File.basename(playbook))
+        if playbooks
+          File.join(sandbox_path, playbooks, File.basename(playbook))
+        else
+          File.join(sandbox_path, File.basename(playbook))
+        end
       end
 
       def tmp_host_vars_dir
@@ -404,6 +408,10 @@ module Kitchen
 
       def role_name
         File.basename(roles) == 'roles' ? '' : File.basename(roles)
+      end
+
+      def playbooks
+        config[:playbook_path]
       end
 
       def modules

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -15,6 +15,7 @@ filter_plugins | filter_plugins | ansible repo filter_plugins directory
 additional_copy_path | | arbitrary array of files and directories to copy into test environment, relative to CWD. (eg, vars or included playbooks)
 extra_vars | Hash.new | Hash to set the extra_vars passed to ansibile-playbook command
 playbook | 'default.yml' | playbook for ansible-playbook to run
+playbook_path | | subdirectory to copy the playbook to
 modules_path | | ansible repo manifests directory
 ansible_verbose| false| Extra information logging
 ansible_verbosity| 1| Sets the verbosity flag appropriately (e.g.: `1 => '-v', 2 => '-vv', 3 => '-vvv" ...`) Valid values are one of: `1, 2, 3, 4` OR `:info, :warn, :debug, :trace`.


### PR DESCRIPTION
Hi,

I've been unable to find a way to infuence where the playbooks are copied to.  Unfortunately we use a pattern like:

var_files:
  - ../passwords.yml

Which means when the playbook is copied to /tmp/kitchen, the same location as our ansible vault, it can't find it.  The easiest fix for this would be for me to be able to set "playbooks" path but unfortunately after trying to add this in I realized the tests don't really cover this functionality and so I couldn't easily test it.

I made this PR just to demonstrate what I think should work in the hope you can either tell me there's a way to do this or patch it up and make it acceptable for use!
