### PR TITLE
Fix error with 'kitchen diagnose'

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -112,6 +112,10 @@ module Kitchen
           return config.key?(k)
         end
 
+        def keys
+          config.keys
+        end
+
         def calculate_path(path, type = :directory)
 
           if not instance

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -30,7 +30,7 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
     platform = instance_double(Kitchen::Platform, :os_type => nil)
   end
 
-  let(:config) do
+  let(:custom_config) do
     {
       :test_base_path => "/b",
       :kitchen_root => "/r",
@@ -38,6 +38,10 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       :playbook => "playbook.yml",
       :ansible_vault_password_file => 'spec/fixtures/vault_password_file'
     }
+  end
+
+  let(:config) do
+    custom_config.dup
   end
 
   let(:suite) do
@@ -118,6 +122,15 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
         # puts "Setting ansible_verbosity to: #{invalid_level} which should raise error"
         config[:ansible_verbosity] = invalid_level
         expect{ provisioner.send(:ansible_verbose_flag) }.to raise_error
+      end
+    end
+  end
+
+  describe "#diagnose" do
+    it "should give a sane diagnostic information" do
+      expect{ provisioner.send(:diagnose) }.to_not raise_error
+      custom_config.each do |k, v|
+        expect( provisioner.send(:diagnose)[k] ).to eq v
       end
     end
   end


### PR DESCRIPTION
`kitchen diagnose` raise an error like below:

```
vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/configurable.rb:115:in `config_keys': undefined method `keys' for #<Kitchen::LazyHash:0x007f8ff3945c98> (NoMethodError)
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/configurable.rb:123:in `diagnose'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/instance.rb:241:in `block in diagnose'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/instance.rb:239:in `each'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/instance.rb:239:in `diagnose'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/diagnostic.rb:127:in `block in prepare_instances'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/diagnostic.rb:127:in `each'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/diagnostic.rb:127:in `prepare_instances'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/diagnostic.rb:54:in `read'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/command/diagnose.rb:41:in `call'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/cli.rb:56:in `perform'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/cli.rb:128:in `diagnose'
        from vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/cli.rb:308:in `invoke_task'
        from vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from vendor/bundle/ruby/2.2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/bin/kitchen:13:in `block in <top (required)>'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/lib/kitchen/errors.rb:154:in `with_friendly_errors'
        from vendor/bundle/ruby/2.2.0/gems/test-kitchen-1.4.1/bin/kitchen:13:in `<top (required)>'
        from bin/kitchen:16:in `load'
        from bin/kitchen:16:in `<main>'
```
So I just defined the method :smile: