### PR TITLE
README.md: Add missing closing paren

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Create your serverspec tests in `test/integration/default/serverspec/localhost/m
   if os[:family] == 'ubuntu'
         describe '/etc/lsb-release' do
           it "exists" do
-              expect(file('/etc/lsb-release').to be_file
+              expect(file('/etc/lsb-release')).to be_file
           end
         end
   end


### PR DESCRIPTION
Without this, the example has an error.