### PR TITLE
make it so install from source is checked first before the repo check

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -68,6 +68,9 @@ module Kitchen
       def install_command
         if config[:require_ansible_omnibus]
           cmd = install_omnibus_command
+        elsif config[:require_ansible_source]
+          info("Installing ansible from source")
+          cmd = install_ansible_from_source_command
         elsif config[:require_ansible_repo]
           case ansible_platform
           when "debian", "ubuntu"
@@ -95,9 +98,6 @@ module Kitchen
             fi
             INSTALL
           end
-        elsif config[:require_ansible_source]
-          info("Installing ansible from source")
-          cmd = install_ansible_from_source_command
         else
           return
         end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -273,15 +273,15 @@ module Kitchen
         if [ ! -d #{config[:root_path]}/ansible ]; then
           if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
             #{update_packages_redhat_cmd}
-            #{sudo('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev
+            #{sudo('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev 
           else
             #{update_packages_debian_cmd}
-            #{sudo('apt-get')} -y install git python python-setuptools
+            #{sudo('apt-get')} -y install git python python-setuptools build-essential python-dev
           fi
 
           git clone git://github.com/ansible/ansible.git --recursive #{config[:root_path]}/ansible
           #{sudo('easy_install')} pip
-          sudo -EH 'pip' install paramiko PyYAML Jinja2 httplib2
+          #{setup_ansible_env_from_source} && pip install paramiko PyYAML Jinja2 httplib2
         fi
         INSTALL
       end


### PR DESCRIPTION
This check needs to occur before the repo checks otherwise it will fail out unless you set both 

  require_ansible_repo: false
  require_ansible_source: true
 
in your kitchen.yml file.