### PR TITLE
provides the ability to define a custom inventory file

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -51,6 +51,7 @@ module Kitchen
         default_config :ansible_check, false
         default_config :ansible_diff, false
         default_config :ansible_platform, ''
+        default_config :ansible_connection, 'local'
         default_config :update_package_repos, true
         default_config :require_ansible_source, false
 
@@ -90,6 +91,10 @@ module Kitchen
 
         default_config :ansible_vault_password_file do |provisioner|
           provisioner.calculate_path('ansible-vault-password', :file)
+        end
+
+        default_config :ansible_inventory_file do |provisioner|
+          provisioner.calculate_path('hosts', :file)
         end
 
         def initialize(config = {})

--- a/spec/fixtures/hosts
+++ b/spec/fixtures/hosts
@@ -1,0 +1,2 @@
+[local]
+localhost

--- a/spec/kitchen/provisioner/ansible/config_spec.rb
+++ b/spec/kitchen/provisioner/ansible/config_spec.rb
@@ -42,6 +42,7 @@ describe Kitchen::Provisioner::Ansible::Config do
       [:ansible_check, false],
       [:ansible_diff, false],
       [:ansible_platform, ''],
+      [:ansible_connection, 'local'],
       [:update_package_repos, true]
     ].each do |item|
       it "should contain the correct default value for '#{item[0]}'" do
@@ -71,6 +72,7 @@ describe Kitchen::Provisioner::Ansible::Config do
       [:ansible_check, true],
       [:ansible_diff, true],
       [:ansible_platform, 'banana'],
+      [:ansible_connection, 'ssh'],
       [:update_package_repos, false]
     ].each do |item|
       it "should contain the correct set value for '#{item[0]}'" do

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -36,7 +36,8 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       :kitchen_root => "/r",
       :log_level => :info,
       :playbook => "playbook.yml",
-      :ansible_vault_password_file => 'spec/fixtures/vault_password_file'
+      :ansible_vault_password_file => 'spec/fixtures/vault_password_file',
+      :ansible_inventory_file => 'spec/fixtures/hosts'
     }
   end
 
@@ -49,7 +50,7 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
   end
 
   let(:instance) do
-    instance_double("Kitchen::Instance", 
+    instance_double("Kitchen::Instance",
       :name => "coolbeans",
       :logger => logger,
       :suite => suite,
@@ -67,12 +68,12 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
   end
 
   describe "#prepare_ansible_vault_password_file" do
-    
+
     it "copies the password file to the sandbox when present" do
       allow(provisioner).to receive(:sandbox_path).and_return(Dir.tmpdir)
       provisioner.send(:prepare_ansible_vault_password_file)
     end
-    
+
     it "noops when the ansible_vault_password_file is not configured" do
       provision_without_vault_configured = Kitchen::Provisioner::AnsiblePlaybook.new(
         config.tap{|config| config.delete(:ansible_vault_password_file)}
@@ -81,6 +82,13 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       allow(provision_without_vault_configured).to receive(:sandbox_path).and_return(Dir.tmpdir)
 
       expect{ provision_without_vault_configured.send(:prepare_ansible_vault_password_file) }.not_to raise_error
+    end
+  end
+
+  describe "#prepare_inventory_file" do
+    it "copies the inventory file to the sandbox when present" do
+      allow(provisioner).to receive(:sandbox_path).and_return(Dir.tmpdir)
+      provisioner.send(:prepare_inventory_file)
     end
   end
 


### PR DESCRIPTION
This PR adds the ability to define a custom ansible inventory file if desired. The main benefit is the ability to assign the localhost host to [custom ansible groups](http://docs.ansible.com/intro_inventory.html#hosts-and-groups) via the inventory file. Currently, the default inventory file only assigns localhost to the default "local" group.