### PR TITLE
Add support for Debian 8 (Jessie)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansible (0.0.21)
+    kitchen-ansible (0.0.22)
       librarian-ansible
       test-kitchen
 

--- a/integration_test/.kitchen.yml
+++ b/integration_test/.kitchen.yml
@@ -20,6 +20,10 @@ platforms:
     driver_config:
       box: chef/centos-6.6
       box_url: https://atlas.hashicorp.com/chef/boxes/centos-6.6
+  - name: debian-jessie
+    driver_config:
+      box: debian/jessie64
+      box_url: https://atlas.hashicorp.com/debian/boxes/jessie64
 
 suites:
   - name: default

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.21"
+    VERSION = "0.0.22"
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -155,7 +155,7 @@ module Kitchen
                   if [ $debvers -ge 8 ]; then
                     # this is jessie or better, where ruby1.9.1 is
                     # no longer in the repositories
-                    PACKAGES="ruby ruby-dev"
+                    PACKAGES="ruby ruby-dev ruby2.1 ruby2.1-dev"
                   fi
                 fi
                 #{sudo('apt-get')} -y install $PACKAGES

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -148,7 +148,17 @@ module Kitchen
             else
               if [ ! $(which ruby) ]; then
                 #{update_packages_debian_cmd}
-                #{sudo('apt-get')} -y install ruby1.9.1 ruby1.9.1-dev
+                # default package selection for Debian/Ubuntu machines
+                PACKAGES="ruby1.9.1 ruby1.9.1-dev"
+                if [ "$(lsb_release -si)" = "Debian" ]; then
+                  debvers=$(sed 's/\\..*//' /etc/debian_version)
+                  if [ $debvers -ge 8 ]; then
+                    # this is jessie or better, where ruby1.9.1 is
+                    # no longer in the repositories
+                    PACKAGES="ruby ruby-dev"
+                  fi
+                fi
+                #{sudo('apt-get')} -y install $PACKAGES
               fi
            fi
            INSTALL


### PR DESCRIPTION
This commit adds support for Debian Jessie (version 8). This was previously unavailable, as there is no ruby1.9.1 package available in the stable repositories for that Debian release.

The changes have been tested against the unit tests, which are all successful:

    Finished in 0.04439 seconds (files took 0.41432 seconds to load)
    48 examples, 0 failures

The integration tests have also been run via test-kitchen. The tests were against the existing platforms (trusty, CentOS 6.6) for regression testing, and against a newly-added **debian/jessie64** box. All pass, except **from-source-centos-6.6**, but this fails in the unmodified branch too due to missing Python dependencies during the build (six, jinja2, yaml, etc are all missing). As this is not a regression introduced by this commit, I have not attempted to resolve it here.