### PR TITLE
adds config logic to allow ansible-playbook to be executed as a non-root user

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -32,6 +32,7 @@ module Kitchen
 
         attr_reader :instance
 
+        default_config :ansible_sudo, true
         default_config :ansible_verbose, false
         default_config :require_ansible_omnibus, false
         default_config :ansible_omnibus_url, nil

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -242,10 +242,10 @@ module Kitchen
 
       def run_command
         if config[:require_ansible_source]
-          # this is an ugly hack to get around the fact that extra vars uses ' and " 
-          cmd = sudo("PATH=#{config[:root_path]}/ansible/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games PYTHONPATH=#{config[:root_path]}/ansible/lib MANPATH=#{config[:root_path]}/ansible/docs/man #{config[:root_path]}/ansible/bin/ansible-playbook")
+          # this is an ugly hack to get around the fact that extra vars uses ' and "
+          cmd = ansible_command("PATH=#{config[:root_path]}/ansible/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games PYTHONPATH=#{config[:root_path]}/ansible/lib MANPATH=#{config[:root_path]}/ansible/docs/man #{config[:root_path]}/ansible/bin/ansible-playbook")
         else
-          cmd = sudo("ansible-playbook")
+          cmd = ansible_command("ansible-playbook")
         end
         [
           cmd,
@@ -262,6 +262,10 @@ module Kitchen
         ].join(" ")
       end
 
+      def ansible_command(script)
+        config[:ansible_sudo].nil? || config[:ansible_sudo] == true ? sudo(script) : script
+      end
+
       protected
 
       def load_needed_dependencies!
@@ -276,7 +280,7 @@ module Kitchen
         if [ ! -d #{config[:root_path]}/ansible ]; then
           if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
             #{update_packages_redhat_cmd}
-            #{sudo('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev 
+            #{sudo('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev
           else
             #{update_packages_debian_cmd}
             #{sudo('apt-get')} -y install git python python-setuptools build-essential python-dev

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -4,6 +4,7 @@
 key | default value | Notes
 ----|---------------|--------
 ansible_version | "latest"| desired version, affects apt installs
+ansible_sudo | true | drives whether ansible-playbook is executed as root or as the current authenticated user
 ansible_platform | naively tries to determine | OS platform of server
 require_ansible_repo | true | Set if using a ansible install from yum or apt repo
 ansible_apt_repo | "ppa:ansible/ansible" | apt repo. see https://launchpad.net /~ansible/+archive/ubuntu/ansible or rquillo/ansible
@@ -30,7 +31,7 @@ ansible_inventory_file | hosts | Custom inventory file
 require_ansible_omnibus | false | Set if using omnibus ansible install
 ansible_omnibus_url | | omnibus ansible install location.
 ansible_omnibus_remote_path | "/opt/ansible" | Server Installation location of an omnibus ansible install.
-require_chef_for_busser|false|install chef to run busser for tests. NOTE: kitchen 1.4 only requires ruby to run busser so this is not required. 
+require_chef_for_busser|false|install chef to run busser for tests. NOTE: kitchen 1.4 only requires ruby to run busser so this is not required.
 chef_bootstrap_url |https://www.getchef.com /chef/install.sh| the chef install
 require_ansible_source | false | Install Ansible from source using method described here: http://docs.ansible.com/intro_installation.html#running-from-source. Only works on Debian/Ubuntu at present.
 
@@ -69,10 +70,10 @@ The provisioner can be configured globally or per suite, global settings act as 
   verifier:
     ruby_bindir: '/usr/bin'
 ```
-where /usr/bin is the location of the ruby command. 
+where /usr/bin is the location of the ruby command.
 
 
-in this example, vagrant will download a box for ubuntu 1204 with no configuration management installed, then install the latest ansible and ansible playbook against a ansible repo from the /repository/ansible_repo directory using the defailt manifest site.yml
+in this example, vagrant will download a box for ubuntu 1204 with no configuration management installed, then install the latest ansible and ansible playbook against a ansible repo from the /repository/ansible_repo directory using the default manifest site.yml
 
 To override a setting at the suite-level, specify the setting name under the suite's attributes:
 

--- a/spec/kitchen/provisioner/ansible/config_spec.rb
+++ b/spec/kitchen/provisioner/ansible/config_spec.rb
@@ -25,6 +25,7 @@ describe Kitchen::Provisioner::Ansible::Config do
   describe "default values" do
 
     [
+      [:ansible_sudo, true],
       [:ansible_verbose, false],
       [:require_ansible_omnibus, false],
       [:ansible_omnibus_url, nil],
@@ -55,6 +56,7 @@ describe Kitchen::Provisioner::Ansible::Config do
   describe "set values" do
 
     [
+      [:ansible_sudo, false],
       [:ansible_verbose, 4],
       [:require_ansible_omnibus, true],
       [:ansible_omnibus_url, 'http://example.com'],


### PR DESCRIPTION
This PR provides the option of not forcing Ansible playbooks to be executed as root.

A key benefit of Ansible is that users do not need to have root access to run Ansible playbooks (allowing them to only escalate to root when needed on a task by task basis). I added a new configuration option called "ansible_sudo". Ideally the default value for this option would be "false" to match the [default behavior in Ansible](http://docs.ansible.com/ansible/intro_configuration.html#become); however, I've set the default configuration in this provisioner to "true" for backwards compatibility and to not disrupt other users of this tool who may have playbooks executing as root by default. 