### PR TITLE
Fix #66: Default to using Chef Omnibus for busser

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansible (0.0.23)
+    kitchen-ansible (0.0.24)
       librarian-ansible
       test-kitchen
 
@@ -61,3 +61,6 @@ DEPENDENCIES
   pry
   rake
   rspec
+
+BUNDLED WITH
+   1.10.3

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.23"
+    VERSION = "0.0.24"
   end
 end

--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -46,8 +46,10 @@ module Kitchen
 	default_config :ansible_sles_repo, "http://download.opensuse.org/repositories/systemsmanagement/SLE_12/systemsmanagement.repo"
 	default_config :python_sles_repo, "http://download.opensuse.org/repositories/devel:/languages:/python/SLE_12/devel:languages:python.repo"
         default_config :chef_bootstrap_url, "https://www.getchef.com/chef/install.sh"
-        default_config :require_chef_for_busser, false
-        default_config :require_ruby_for_busser, true
+        # Until we can truly make busser work without /opt/chef/embedded/bin/gem being installed, we still need Chef Omnibus
+        # (Reference: https://github.com/neillturner/kitchen-ansible/issues/66 )
+        default_config :require_chef_for_busser, true
+        default_config :require_ruby_for_busser, false
         default_config :requirements_path, false
         default_config :ansible_verbose, false
         default_config :ansible_verbosity, 1


### PR DESCRIPTION
Since it appears there was a regression in `kitchen-ansible` when trying to install busser without Chef Omnibus,
for now we should probably default to using it still.

This PR sets the defaults for the following variables:

 - `require_chef_for_busser `: `true`
 - `require_ruby_for_busser`: `false`