### PR TITLE
Log ansible-playbook command to be used

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -274,7 +274,7 @@ module Kitchen
         if http_proxy
           cmd = "HTTP_PROXY=#{http_proxy} #{cmd}"
         end
-        [
+        result = [
           cmd,
           ansible_inventory_flag,
           "-c #{config[:ansible_connection]}",
@@ -287,6 +287,8 @@ module Kitchen
           tags,
           "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
         ].join(" ")
+        info("Going to invoke ansible-playbook with: #{result}")
+        result
       end
 
       def ansible_command(script)


### PR DESCRIPTION
It is very useful to understand how kitchen-ansible works and is useful when debugging or developing.

e.g.:

    Going to invoke ansible-playbook with: sudo -E ansible-playbook --inventory-file=/tmp/kitchen/static_hosts -c local -M /tmp/kitchen/modules -v       /tmp/kitchen/vagrant_base.yml

Cc: @sudarkoff, @bszonye