### PR TITLE
Add ansible_extra_flags option

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -285,6 +285,7 @@ module Kitchen
           ansible_vault_flag,
           extra_vars,
           tags,
+          ansible_extra_flags,
           "#{File.join(config[:root_path], File.basename(config[:playbook]))}",
         ].join(" ")
       end
@@ -531,6 +532,10 @@ module Kitchen
 
       def ansible_inventory_flag
           config[:ansible_inventory_file] ? "--inventory-file=#{File.join(config[:root_path], File.basename(config[:ansible_inventory_file]))}" : "--inventory-file=#{File.join(config[:root_path], 'hosts')}"
+      end
+
+      def ansible_extra_flags
+        config[:ansible_extra_flags] || ''
       end
 
       def ansible_platform

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -36,6 +36,7 @@ requirements_path | | Path to ansible-galaxy requirements
 ansible_vault_password_file| | Path of Ansible Vault Password File
 ansible_connection | local | Connection for Hosts and Groups
 ansible_inventory_file | hosts | Custom inventory file
+ansible_extra_flags | '' | Additional options to pass to `ansible-playbook` -- e.g.: `'--skip-tags=redis'`
 require_ruby_for_busser|false|install ruby to run busser for tests
 require_chef_for_busser|true|install chef to run busser for tests. NOTE: kitchen 1.4 only requires ruby to run busser so this is not required.
 chef_bootstrap_url |https://www.getchef.com /chef/install.sh| the chef install

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -37,7 +37,8 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       :log_level => :info,
       :playbook => "playbook.yml",
       :ansible_vault_password_file => 'spec/fixtures/vault_password_file',
-      :ansible_inventory_file => 'spec/fixtures/hosts'
+      :ansible_inventory_file => 'spec/fixtures/hosts',
+      :ansible_extra_flags => '--skip-tags=skipme'
     }
   end
 
@@ -63,7 +64,7 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
 
   describe "#run_command" do
     it "should give a sane run_command" do
-      expect(provisioner.run_command).to match(/ansible-playbook/)
+      expect(provisioner.run_command).to match(/ansible-playbook.*--skip-tags=skipme.*/)
     end
   end
 


### PR DESCRIPTION
to allow passing additional flags to `ansible-playbook` -- e.g.:

```yaml
 provisioner:

   name: ansible_playbook
   ...
   ansible_extra_flags: --skip-tags=apt,freetds,redis
```

With this, folks can use all features of whatever version of Ansible they have installed and kitchen-ansible doesn't have to add a new config option for every Ansible feature, unless it's something that's very commonly used. I needed this so that I could pass the `--skip-tags` option to `ansible-playbook`, but I'm guessing that this is not a very common need.

```
[marca@marca-mac2 kitchen-ansible]$ bundle exec rake test
/usr/local/Cellar/ruby/2.2.2/bin/ruby -I/Users/marca/dev/git-repos/kitchen-ansible/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.2.3/lib:/Users/marca/dev/git-repos/kitchen-ansible/vendor/bundle/ruby/2.2.0/gems/rspec-support-3.2.2/lib /Users/marca/dev/git-repos/kitchen-ansible/vendor/bundle/ruby/2.2.0/gems/rspec-core-3.2.3/exe/rspec spec/kitchen/provisioner/ansible/config_spec.rb spec/kitchen/provisioner/ansible_playbook_spec.rb --format documentation

Kitchen::Provisioner::Ansible::Config
  default values
    should contain the correct default value for 'ansible_sudo'
    should contain the correct default value for 'ansible_verbose'
    should contain the correct default value for 'require_ansible_omnibus'
    should contain the correct default value for 'ansible_omnibus_url'
    should contain the correct default value for 'ansible_omnibus_remote_path'
    should contain the correct default value for 'ansible_version'
    should contain the correct default value for 'require_ansible_repo'
    should contain the correct default value for 'extra_vars'
    should contain the correct default value for 'tags'
    should contain the correct default value for 'ansible_apt_repo'
    should contain the correct default value for 'ansible_yum_repo'
    should contain the correct default value for 'ansible_sles_repo'
    should contain the correct default value for 'python_sles_repo'
    should contain the correct default value for 'chef_bootstrap_url'
    should contain the correct default value for 'requirements_path'
    should contain the correct default value for 'ansible_verbose'
    should contain the correct default value for 'ansible_verbosity'
    should contain the correct default value for 'ansible_check'
    should contain the correct default value for 'ansible_diff'
    should contain the correct default value for 'ansible_platform'
    should contain the correct default value for 'ansible_connection'
    should contain the correct default value for 'update_package_repos'
    should contain the correct default value for 'http_proxy'
    should contain the correct default value for 'https_proxy'
  set values
    should contain the correct set value for 'ansible_sudo'
    should contain the correct set value for 'ansible_verbose'
    should contain the correct set value for 'require_ansible_omnibus'
    should contain the correct set value for 'ansible_omnibus_url'
    should contain the correct set value for 'ansible_omnibus_remote_path'
    should contain the correct set value for 'ansible_version'
    should contain the correct set value for 'require_ansible_repo'
    should contain the correct set value for 'extra_vars'
    should contain the correct set value for 'tags'
    should contain the correct set value for 'ansible_apt_repo'
    should contain the correct set value for 'ansible_yum_repo'
    should contain the correct set value for 'ansible_sles_repo'
    should contain the correct set value for 'python_sles_repo'
    should contain the correct set value for 'chef_bootstrap_url'
    should contain the correct set value for 'requirements_path'
    should contain the correct set value for 'ansible_verbose'
    should contain the correct set value for 'ansible_verbosity'
    should contain the correct set value for 'ansible_check'
    should contain the correct set value for 'ansible_diff'
    should contain the correct set value for 'ansible_platform'
    should contain the correct set value for 'ansible_connection'
    should contain the correct set value for 'update_package_repos'

Kitchen::Provisioner::AnsiblePlaybook
  #run_command
    should give a sane run_command
  #prepare_ansible_vault_password_file
    copies the password file to the sandbox when present
    noops when the ansible_vault_password_file is not configured
  #prepare_inventory_file
    copies the inventory file to the sandbox when present
  configuration
    should not be verbose by default
    should be configured to be verbose when ansible_verbose is set
    should generate the flag for 4 verbosity levels
    should understand log level names and convert to a number of -v flags
    should raise an error if invalid verbosity level is given
  #diagnose
    should give a sane diagnostic information

Finished in 0.04247 seconds (files took 0.31526 seconds to load)
56 examples, 0 failures
```

Cc: @sudarkoff, @bszonye