### PR TITLE
Add Debian Squeeze support for kitchen-ansible

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -173,6 +173,10 @@ module Kitchen
                     # for enable ruby1.9.1
                     ALTERNATIVES_STRING="--install /usr/bin/ruby ruby /usr/bin/ruby1.9.1 10 --slave /usr/share/man/man1/ruby.1.gz ruby.1.gz /usr/share/man/man1/ruby1.9.1.1.gz --slave /usr/bin/erb erb /usr/bin/erb1.9.1 --slave /usr/bin/gem gem /usr/bin/gem1.9.1 --slave /usr/bin/irb irb /usr/bin/irb1.9.1 --slave /usr/bin/rake rake /usr/bin/rake1.9.1 --slave /usr/bin/rdoc rdoc /usr/bin/rdoc1.9.1 --slave /usr/bin/testrb testrb /usr/bin/testrb1.9.1 --slave /usr/share/man/man1/erb.1.gz erb.1.gz /usr/share/man/man1/erb1.9.1.1.gz --slave /usr/share/man/man1/gem.1.gz gem.1.gz /usr/share/man/man1/gem1.9.1.1.gz --slave /usr/share/man/man1/irb.1.gz irb.1.gz /usr/share/man/man1/irb1.9.1.1.gz --slave /usr/share/man/man1/rake.1.gz rake.1.gz /usr/share/man/man1/rake1.9.1.1.gz --slave /usr/share/man/man1/rdoc.1.gz rdoc.1.gz /usr/share/man/man1/rdoc1.9.1.1.gz --slave /usr/share/man/man1/testrb.1.gz testrb.1.gz /usr/share/man/man1/testrb1.9.1.1.gz"
                     #{sudo_env('update-alternatives')} $ALTERNATIVES_STRING
+                    #{sudo_env('gem')} install rubygems-update
+                    #{sudo_env('/var/lib/gems/1.9.1/bin/update_rubygems')}
+                    # clear local gem cache
+                    #{sudo_env('rm')} -r /home/vagrant/.gem
                 fi
               fi
            fi

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -173,6 +173,7 @@ module Kitchen
                     # for enable ruby1.9.1
                     ALTERNATIVES_STRING="--install /usr/bin/ruby ruby /usr/bin/ruby1.9.1 10 --slave /usr/share/man/man1/ruby.1.gz ruby.1.gz /usr/share/man/man1/ruby1.9.1.1.gz --slave /usr/bin/erb erb /usr/bin/erb1.9.1 --slave /usr/bin/gem gem /usr/bin/gem1.9.1 --slave /usr/bin/irb irb /usr/bin/irb1.9.1 --slave /usr/bin/rake rake /usr/bin/rake1.9.1 --slave /usr/bin/rdoc rdoc /usr/bin/rdoc1.9.1 --slave /usr/bin/testrb testrb /usr/bin/testrb1.9.1 --slave /usr/share/man/man1/erb.1.gz erb.1.gz /usr/share/man/man1/erb1.9.1.1.gz --slave /usr/share/man/man1/gem.1.gz gem.1.gz /usr/share/man/man1/gem1.9.1.1.gz --slave /usr/share/man/man1/irb.1.gz irb.1.gz /usr/share/man/man1/irb1.9.1.1.gz --slave /usr/share/man/man1/rake.1.gz rake.1.gz /usr/share/man/man1/rake1.9.1.1.gz --slave /usr/share/man/man1/rdoc.1.gz rdoc.1.gz /usr/share/man/man1/rdoc1.9.1.1.gz --slave /usr/share/man/man1/testrb.1.gz testrb.1.gz /usr/share/man/man1/testrb1.9.1.1.gz"
                     #{sudo_env('update-alternatives')} $ALTERNATIVES_STRING
+                    # need to update gem tool because gem 1.3.7 from ruby 1.9.1 is broken
                     #{sudo_env('gem')} install rubygems-update
                     #{sudo_env('/var/lib/gems/1.9.1/bin/update_rubygems')}
                     # clear local gem cache

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -168,6 +168,12 @@ module Kitchen
                   fi
                 fi
                 #{sudo_env('apt-get')} -y install $PACKAGES
+                if [ $debvers -eq 6 ]; then
+                    # in squeeze we need to update alternatives
+                    # for enable ruby1.9.1
+                    ALTERNATIVES_STRING="--install /usr/bin/ruby ruby /usr/bin/ruby1.9.1 10 --slave /usr/share/man/man1/ruby.1.gz ruby.1.gz /usr/share/man/man1/ruby1.9.1.1.gz --slave /usr/bin/erb erb /usr/bin/erb1.9.1 --slave /usr/bin/gem gem /usr/bin/gem1.9.1 --slave /usr/bin/irb irb /usr/bin/irb1.9.1 --slave /usr/bin/rake rake /usr/bin/rake1.9.1 --slave /usr/bin/rdoc rdoc /usr/bin/rdoc1.9.1 --slave /usr/bin/testrb testrb /usr/bin/testrb1.9.1 --slave /usr/share/man/man1/erb.1.gz erb.1.gz /usr/share/man/man1/erb1.9.1.1.gz --slave /usr/share/man/man1/gem.1.gz gem.1.gz /usr/share/man/man1/gem1.9.1.1.gz --slave /usr/share/man/man1/irb.1.gz irb.1.gz /usr/share/man/man1/irb1.9.1.1.gz --slave /usr/share/man/man1/rake.1.gz rake.1.gz /usr/share/man/man1/rake1.9.1.1.gz --slave /usr/share/man/man1/rdoc.1.gz rdoc.1.gz /usr/share/man/man1/rdoc1.9.1.1.gz --slave /usr/share/man/man1/testrb.1.gz testrb.1.gz /usr/share/man/man1/testrb1.9.1.1.gz"
+                    #{sudo_env('update-alternatives')} $ALTERNATIVES_STRING
+                fi
               fi
            fi
            INSTALL


### PR DESCRIPTION
Debian Squeeze have 2 problems.

1) By default, /usr/bin/ruby pointed to ruby1.8 or, if ruby1.8 not installed, /usr/bin/ruby is missing. Need to run update-alternatives after ruby1.9.1 install. Related topic on SO - http://stackoverflow.com/questions/6965277/how-to-set-ruby1-9-1-as-default-version-on-debian-squeeze
2) 'Gem' tool from ruby1.9.1 package (gem 1.3.7) is broken. Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=588125, more related topics: https://bbs.archlinux.org/viewtopic.php?id=113613, http://help.rubygems.org/discussions/problems/445-gem-update-system-fails-undefined-method-path-for-gemmodule-nomethoderror. Need to install 'rubygems-update' gem and run 'update_rubygems'.