### PR TITLE
Added six to the pip modules to install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansible (0.0.27)
+    kitchen-ansible (0.0.28)
       librarian-ansible
       test-kitchen
 

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.27"
+    VERSION = "0.0.28"
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -337,7 +337,7 @@ module Kitchen
           #{export_http_proxy}
           git clone git://github.com/ansible/ansible.git --recursive #{config[:root_path]}/ansible
           #{sudo_env('easy_install')} pip
-          #{sudo_env('pip')} install paramiko PyYAML Jinja2 httplib2
+          #{sudo_env('pip')} install six paramiko PyYAML Jinja2 httplib2
         fi
         INSTALL
       end


### PR DESCRIPTION
Testing against various versions of linux, it seems that only Ubuntu 14.04 had the "six" pip package installed by default. I'm requesting this pull request to be merged so that the ansible provisioner installs six.

Edit: Ansible seems to break without 6 during the converge step, so six appears to be a requirement.