### PR TITLE
Allow overriding of path where kitchen looks for ansible-playbook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kitchen-ansible (0.0.28)
+    kitchen-ansible (0.0.29)
       librarian-ansible
       test-kitchen
 

--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,5 +1,5 @@
 module Kitchen
   module Ansible
-    VERSION = "0.0.28"
+    VERSION = "0.0.29"
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -279,6 +279,9 @@ module Kitchen
         else
           cmd = ansible_command("ansible-playbook")
         end
+        if config[:ansible_binary_path]
+          cmd = ansible_command("#{config[:ansible_binary_path]}/ansible-playbook")
+        end
         if https_proxy
           cmd = "HTTPS_PROXY=#{https_proxy} #{cmd}"
         end

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -9,6 +9,7 @@ ansible_platform | naively tries to determine | OS platform of server
 require_ansible_repo | true | Set if using a ansible install from yum or apt repo
 ansible_apt_repo | "ppa:ansible/ansible" | apt repo. see https://launchpad.net /~ansible/+archive/ubuntu/ansible or rquillo/ansible
 ansible_yum_repo | https://download.fedoraproject.org /pub/epel/6/i386/epel-release-6-8.noarch.rpm | yum repo RH/Centos6
+ansible_binary_path | NULL | If specified this will override the location where kitchen tries to run ansible-playbook from. ie: (ansible_binary_path: /usr/local/bin )
 _for RH/Centos7 change to_ | http://dl.fedoraproject.org /pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm | 
 enable_yum_epel  | false | enable yum EPEL repo  
 ansible_sles_repo | http://download.opensuse.org/repositories /systemsmanagement/SLE_12/systemsmanagement.repo | zypper suse ansible repo


### PR DESCRIPTION
Added a provisioner option to override the path ansible-playbook is looked for in. This is useful for vagrant boxes where ansible is installed in an alternate location and also helps with issue #98