### PR TITLE
Skip generating the hosts file if the ansible inventory file is specified

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -752,6 +752,7 @@ module Kitchen
       # [example_servers]
       # localhost
       def prepare_hosts
+        return if ansible_inventory_file
         info('Preparing hosts file')
 
         if config[:hosts].nil?


### PR DESCRIPTION
This plugin allows you to either dynamically generate a hosts file from
`hosts` or use one in the test/integration folder. When you use the
latter, the plugin requires something to be set for `hosts`. If you set
something for `hosts`, it overrides the file copied from
test/integration.