### PR TITLE
New: Split installation scripts into their own classes

### DIFF
--- a/lib/kitchen/provisioner/ansible/os.rb
+++ b/lib/kitchen/provisioner/ansible/os.rb
@@ -1,0 +1,75 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'json'
+require 'kitchen/provisioner/ansible/os/debian'
+require 'kitchen/provisioner/ansible/os/redhat'
+require 'kitchen/provisioner/ansible/os/amazon'
+require 'kitchen/provisioner/ansible/os/suse'
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      class Os
+
+        attr_accessor :name
+
+        def initialize(name, config)
+          @config = config
+          @name = name
+        end
+
+        def self.make(platform, config)
+          puts platform
+          return nil if platform == ''
+
+          case platform
+          when "debian", "ubuntu"
+            Debian.new(platform, config)
+          when "redhat", "centos", "fedora"
+            Redhat.new(platform, config)
+          when "amazon"
+            Amazon.new(platform, config)
+          when "suse", "opensuse", "sles"
+            Suse.new(platform, config)
+          else
+            nil
+          end
+        end
+
+        # Helpers
+        def sudo_env(pm)
+          s = @config[:https_proxy] ? "https_proxy=#{@config[:https_proxy]}" : nil
+          p = @config[:http_proxy] ? "http_proxy=#{@config[:http_proxy]}" : nil
+          n = @config[:no_proxy] ? "no_proxy=#{@config[:no_proxy]}" : nil
+          p || s ? "#{sudo('env')} #{p} #{s} #{n} #{pm}" : "#{sudo(pm)}"
+        end
+
+        # Taken from https://github.com/test-kitchen/test-kitchen/blob/master/lib/kitchen/provisioner/base.rb
+        def sudo(script)
+          @config[:sudo] ? "#{@config[:sudo_command]} #{script}" : script
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      class Os
+        class Amazon < Redhat
+
+          def install_command
+            <<-INSTALL
+            if [ ! $(which ansible) ]; then
+              #{install_epel_repo}
+              #{sudo_env('yum-config-manager')} --enable epel/x86_64
+              #{sudo_env('yum')} -y install ansible#{ansible_redhat_version} git
+              #{sudo_env('alternatives')} --set python /usr/bin/python2.6
+              #{sudo_env('yum')} clean all
+              #{sudo_env('yum')} install yum-python26 -y
+            fi
+            INSTALL
+          end
+
+        end
+      end
+    end
+  end
+end
+
+

--- a/lib/kitchen/provisioner/ansible/os/debian.rb
+++ b/lib/kitchen/provisioner/ansible/os/debian.rb
@@ -1,0 +1,64 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      class Os
+        class Debian < Os
+
+          def update_packages_command
+            @config[:update_package_repos] ? "#{sudo_env('apt-get')} update" : nil
+          end
+
+          def install_command
+            <<-INSTALL
+            if [ ! $(which ansible) ]; then
+              #{update_packages_command}
+
+              ## Install apt-utils to silence debconf warning: http://serverfault.com/q/358943/77156
+              #{sudo_env('apt-get')} -y install apt-utils git
+
+              ## Fix debconf tty warning messages
+              export DEBIAN_FRONTEND=noninteractive
+
+              ## 13.10, 14.04 include add-apt-repository in software-properties-common
+              #{sudo_env('apt-get')} -y install software-properties-common
+
+              ## 10.04, 12.04 include add-apt-repository in
+              #{sudo_env('apt-get')} -y install python-software-properties
+
+              ## 10.04 version of add-apt-repository doesn't accept --yes
+              ## later versions require interaction from user, so we must specify --yes
+              ## First try with -y flag, else if it fails, try without.
+              ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
+              #{sudo_env('add-apt-repository')} -y #{@config[:ansible_apt_repo]} || #{sudo_env('add-apt-repository')} #{@config[:ansible_apt_repo]}
+              #{sudo_env('apt-get')} update
+              #{sudo_env('apt-get')} -y install ansible
+            fi
+            INSTALL
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/ansible/os/redhat.rb
+++ b/lib/kitchen/provisioner/ansible/os/redhat.rb
@@ -1,0 +1,57 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      class Os
+        class Redhat < Os
+
+          def install_command
+            <<-INSTALL
+            if [ ! $(which ansible) ]; then
+            #{install_epel_repo}
+            #{sudo_env('rpm')} -ivh #{@config[:ansible_yum_repo]}
+            #{update_packages_command}
+            #{sudo_env('yum')} -y install ansible#{ansible_redhat_version} libselinux-python git
+            fi
+            INSTALL
+          end
+
+          def update_packages_command
+            @config[:update_package_repos] ? "#{sudo_env('yum')} makecache" : nil
+          end
+
+          def install_epel_repo
+            @config[:enable_yum_epel] ? sudo_env('yum install epel-release -y') : nil
+          end
+
+          def ansible_redhat_version
+            @config[:ansible_version] ? "-#{@config[:ansible_version]}" : nil
+          end
+
+
+        end
+      end
+    end
+  end
+end
+

--- a/lib/kitchen/provisioner/ansible/os/suse.rb
+++ b/lib/kitchen/provisioner/ansible/os/suse.rb
@@ -1,0 +1,49 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+
+  module Provisioner
+
+    module Ansible
+      class Os
+        class Suse < Os
+
+          def install_command
+            <<-INSTALL
+            if [ ! $(which ansible) ]; then
+              #{sudo_env('zypper')} ar #{@config[:python_sles_repo]}
+              #{sudo_env('zypper')} ar #{@config[:ansible_sles_repo]}
+              #{update_packages_command}
+              #{sudo_env('zypper')} --non-interactive install ansible
+            fi
+            INSTALL
+          end
+
+          def update_packages_command
+            @config[:update_package_repos] ? "#{sudo_env('zypper')} --gpg-auto-import-keys ref" : nil
+          end
+
+        end
+      end
+    end
+  end
+end
+
+

--- a/spec/kitchen/provisioner/ansible/os_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os_spec.rb
@@ -1,0 +1,92 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kitchen'
+require 'kitchen/provisioner/ansible/os'
+
+# Work around for lazy loading
+describe Kitchen::Provisioner::Ansible::Os do
+
+  describe "make new instance" do
+
+    it "returns nil for an unknown os" do
+      c = Kitchen::Provisioner::Ansible::Os.make("dinosaurs", [])
+      expect(c).to equal nil
+    end
+
+    [
+      ["debian", Kitchen::Provisioner::Ansible::Os::Debian],
+      ["ubuntu", Kitchen::Provisioner::Ansible::Os::Debian],
+      ["redhat", Kitchen::Provisioner::Ansible::Os::Redhat],
+      ["centos", Kitchen::Provisioner::Ansible::Os::Redhat],
+      ["fedora", Kitchen::Provisioner::Ansible::Os::Redhat],
+      ["amazon", Kitchen::Provisioner::Ansible::Os::Amazon],
+      ["suse", Kitchen::Provisioner::Ansible::Os::Suse],
+    ].each do |item|
+      it "return the correct class for '#{item[0]}'" do
+        c = Kitchen::Provisioner::Ansible::Os.make(item[0], [])
+        expect(c).to be_an_instance_of (item[1])
+      end
+    end
+  end
+
+  describe "sudo_env" do
+
+    it "returns just sudo with no additional config" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config)
+      expect(c.sudo_env("ls")).to eq("sudo ls")
+    end
+
+    it "can be provided with a https_proxy" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config({:https_proxy => 'https://localhost:1234'}))
+      expect(c.sudo_env("ls")).to eq("sudo env  https_proxy=https://localhost:1234  ls")
+    end
+
+    it "can be provided with a http_proxy" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config({:http_proxy => 'http://localhost:5678'}))
+      expect(c.sudo_env("ls")).to eq("sudo env http_proxy=http://localhost:5678   ls")
+    end
+
+    it "can be provided with no_proxy only and does not populate" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config({:no_proxy => 'http://localhost:9999'}))
+      expect(c.sudo_env("ls")).to eq("sudo ls")
+    end
+
+    it "can be provided with no_proxy and http_proxy and does populate both" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config({:http_proxy => 'http://localhost:5678',
+                                                                   :no_proxy => 'http://localhost:9999'}))
+      expect(c.sudo_env("ls")).to eq("sudo env http_proxy=http://localhost:5678  no_proxy=http://localhost:9999 ls")
+    end
+
+    it "can be provided with all proxy options" do
+      c = Kitchen::Provisioner::Ansible::Os.new("testing", config({:https_proxy => 'https://localhost:1234',
+                                                                   :http_proxy => 'http://localhost:5678',
+                                                                   :no_proxy => 'http://localhost:9999'}))
+      expect(c.sudo_env("ls")).to eq("sudo env http_proxy=http://localhost:5678 https_proxy=https://localhost:1234 no_proxy=http://localhost:9999 ls")
+    end
+
+  end
+
+end
+
+def config(values = {})
+  Kitchen::Provisioner::Ansible::Config.new({
+    :sudo => true,
+    :sudo_command => "sudo"
+  }.merge!(values))
+end


### PR DESCRIPTION
This is the first of a series of refactors to reduce the size of
ansible_playbook.rb and use polymorphism rather than if/else
statements to accomplish the same goals.

Each operating system now has it's own class. For now, I've only moved
the installation methods to them, but the rest should follow shortly.

This has been tested by setting ansible_platform in .kitchen.yml with
the following values: debian, redhat, amazon, suse