### PR TITLE
Removed needless install_epel_repo

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -379,7 +379,6 @@ module Kitchen
         if [ ! -d "#{config[:ansible_omnibus_remote_path]}" ]; then
           echo "-----> Installing Ansible Omnibus"
           #{export_http_proxy}
-          #{install_epel_repo}
           do_download #{config[:ansible_omnibus_url]} /tmp/ansible_install.sh
           #{sudo_env('sh')} /tmp/ansible_install.sh #{version}
         fi


### PR DESCRIPTION
I have an issue with `require_ansible_omnibus: true` for ubuntu: 
```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: Failed to complete #converge action: [undefined local variable or method `install_epel_repo' for #<Kitchen::Provisioner::AnsiblePlaybook:0x007fd35bac0338>]
```

IMHO `install_epel_repo` is not needed here because epel installed by `omnibus-ansible`