### PR TITLE
Add ssh_known_hosts options

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -51,6 +51,7 @@ module Kitchen
         default_config :require_chef_for_busser, true
         default_config :require_ruby_for_busser, false
         default_config :requirements_path, false
+        default_config :ssh_known_hosts, nil
         default_config :ansible_verbose, false
         default_config :ansible_verbosity, 1
         default_config :ansible_check, false

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -250,6 +250,13 @@ module Kitchen
           sudo_env('cp -r'), File.join(config[:root_path], 'host_vars'), '/etc/ansible/.'
         ].join(' ')
 
+        if config[:ssh_known_hosts]
+          config[:ssh_known_hosts].each do |host|
+            info("Add #{host} to ~/.ssh/known_hosts")
+            commands << "ssh-keyscan #{host} > ~/.ssh/known_hosts 2> /dev/null"
+          end
+        end
+
         if galaxy_requirements
           if config[:require_ansible_source]
             commands << setup_ansible_env_from_source

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -50,6 +50,7 @@ ansible_source_rev | | Branch or Tag to install ansible source
 ansible_host_key_checking | true | strict host key checking in ssh
 private_key | | ssh private key file for ssh connection
 idempotency_test | false | Enable to test ansible playbook idempotency
+ssh_known_hosts | | List of hosts that should be added to `~/.ssh/known_hosts`
 
 ## Configuring Provisioner Options
 


### PR DESCRIPTION
Since I have same issue like #87, i guess it will be great to have option to dynamically generate `~/.ssh/known_hosts` file. 

To enable SSH Agent Forwarding we need explicitly create a transport config block, more here - https://github.com/test-kitchen/test-kitchen/issues/807

Example:

```
---
driver:
  name: vagrant

provisioner:
  name: ansible_playbook
  hosts: all
  requirements_path: galaxy.yml
  ssh_known_hosts:
  - gitlab.example.com
  - git.example.com

verifier:
  ruby_bindir: '/usr/bin'

platforms:
  - name: centos-6.7
    driver_config:
      box: bento/centos-6.7

suites:
  - name: default

transport:
  forward_agent: true
```