### PR TITLE
Use `attr_accessor` instead of `writer` & `reader`

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -28,8 +28,7 @@ module Kitchen
       class Config
         include Kitchen::Configurable
 
-        attr_writer :instance
-        attr_reader :instance
+        attr_accessor :instance
 
         default_config :ansible_sudo, true
         default_config :ansible_verbose, false


### PR DESCRIPTION
Change getter/setter methods for `:instance` for more semantic definition :sparkles: 

All tests still passing.