### PR TITLE
Install ruby2.1 on Ubuntu utopic and newer

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -184,6 +184,13 @@ module Kitchen
                     PACKAGES="ruby ruby-dev ruby2.1 ruby2.1-dev"
                   fi
                 fi
+                if [ "$(lsb_release -si)" = "Ubuntu" ]; then
+                  ubuntuvers=$(lsb_release -sr | tr -d .)
+                  if [ $ubuntuvers -ge 1410 ]; then
+                    # Default ruby is 2.x in utopic and newer
+                    PACKAGES="ruby ruby-dev ruby2.1 ruby2.1-dev"
+                  fi
+                fi
                 #{sudo_env('apt-get')} -y install $PACKAGES
                 if [ $debvers -eq 6 ]; then
                     # in squeeze we need to update alternatives


### PR DESCRIPTION
The default ruby on Ubuntu Utopic (14.10) and newer is ruby 2.1 [1]. Install the ruby2.1 packages so serverspec will run.

Fixes #144 

[1] http://packages.ubuntu.com/vivid/ruby