### PR TITLE
Install ruby default packages on Ubuntu

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -188,7 +188,7 @@ module Kitchen
                   ubuntuvers=$(lsb_release -sr | tr -d .)
                   if [ $ubuntuvers -ge 1410 ]; then
                     # Default ruby is 2.x in utopic and newer
-                    PACKAGES="ruby ruby-dev ruby2.1 ruby2.1-dev"
+                    PACKAGES="ruby ruby-dev"
                   fi
                 fi
                 #{sudo_env('apt-get')} -y install $PACKAGES


### PR DESCRIPTION
Ruby 2.1 packages are not available on Ubuntu Xenial (16.04). Installing
ruby and ruby-dev installs the default version of ruby, which will do
the right thing.