### PR TITLE
fix ansible_debian_version

### DIFF
--- a/lib/kitchen/provisioner/ansible/os/debian.rb
+++ b/lib/kitchen/provisioner/ansible/os/debian.rb
@@ -27,7 +27,11 @@ module Kitchen
           end
 
           def ansible_debian_version
-            @config[:ansible_version] ? "=#{@config[:ansible_version]}" : nil
+            if @config[:ansible_version] == 'latest' || @config[:ansible_version] == nil
+              ''
+            else
+              "=#{@config[:ansible_version]}"
+            end
           end
 
           def install_command

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -585,7 +585,11 @@ module Kitchen
       end
 
       def ansible_debian_version
-        config[:ansible_version] ? "=#{config[:ansible_version]}" : nil
+        if @config[:ansible_version] == 'latest' || @config[:ansible_version] == nil
+          ''
+        else
+          "=#{@config[:ansible_version]}"
+        end
       end
 
       def ansible_connection_flag

--- a/spec/kitchen/provisioner/ansible/config_spec.rb
+++ b/spec/kitchen/provisioner/ansible/config_spec.rb
@@ -16,8 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'kitchen'
-require 'kitchen/provisioner/ansible/config'
+require 'spec_helper'
 
 # Work around for lazy loading
 describe Kitchen::Provisioner::Ansible::Config do

--- a/spec/kitchen/provisioner/ansible/os/debian_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os/debian_spec.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'spec_helper'
+
 require 'kitchen/provisioner/ansible/os'
 require 'kitchen/provisioner/ansible/os/debian'
 
@@ -25,17 +27,23 @@ describe Kitchen::Provisioner::Ansible::Os::Debian do
   let (:debian) { Kitchen::Provisioner::Ansible::Os.make('debian', config) }
   describe 'install_command' do
     subject(:install_command) { debian.install_command }
-    
+
     context 'when no ansible version is specified in the config' do
       let (:config) { empty_config }
 
       it { is_expected.to match /apt-get -y install ansible\s*$/m }
     end
 
-    context 'when an ansible version is specified in the config' do
+    context 'when an ansible version (1.2.3) is specified in the config' do
       let (:config) { config_with(ansible_version: "1.2.3") }
-   
+
       it { is_expected.to match /apt-get -y install ansible=1.2.3/ }
+    end
+
+    context 'when an ansible version (latest) is specified in the config' do
+      let (:config) { config_with(ansible_version: "latest") }
+
+      it { is_expected.to match /apt-get -y install ansible/ }
     end
   end
 end

--- a/spec/kitchen/provisioner/ansible/os_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os_spec.rb
@@ -16,7 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'kitchen'
+require 'spec_helper'
+
 require 'kitchen/provisioner/ansible/os'
 
 include Kitchen::Ansible::TestHelpers

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -16,8 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../spec_helper'
-require 'kitchen'
+require 'spec_helper'
 
 # Work around for lazy loading
 require 'kitchen/provisioner/ansible_playbook'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,9 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'pry'
 require 'rspec'
 
+require 'kitchen'
+require 'kitchen/provisioner/ansible/config'
+
 RSpec.configure do |config|
   config.tty = true
   config.color = true


### PR DESCRIPTION
Hi

When I set `ansible_version: latest`, the Ubuntu 14.04 report `E: Version 'latest' for 'ansible' was not found`

Then, I run `apt-cache search ansible`, the result is this
```
ansible-doc - Ansible documentation and examples
ansible-fireball - Ansible fireball transport support
ansible-node-fireball - Ansible fireball transport support for nodes
python-reclass - hierarchical inventory backend for configuration management systems
reclass - hierarchical inventory backend for configuration management systems
ansible - A radically simple IT automation platform
``` 

So, I fix this bug, and add rspec to tested it.

Please review it. thanks.




