### PR TITLE
Allow role name to be specified in configuration.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,13 @@ PATH
   specs:
     kitchen-ansible (0.42.3)
       librarian-ansible
+      net-ssh (~> 3.0)
       test-kitchen (~> 1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    artifactory (2.3.2)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     faraday (0.9.2)
@@ -16,15 +18,20 @@ GEM
     librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-ansible (1.0.6)
+    librarian-ansible (3.0.0)
       faraday
       librarian (~> 0.1.0)
     method_source (0.8.2)
-    mixlib-shellout (2.2.5)
+    mixlib-install (1.0.11)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
+    mixlib-shellout (2.2.6)
+    mixlib-versioning (1.1.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (3.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -45,10 +52,11 @@ GEM
     rspec-support (3.3.0)
     safe_yaml (1.0.4)
     slop (3.6.0)
-    test-kitchen (1.4.2)
+    test-kitchen (1.8.0)
+      mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
-      net-ssh (~> 2.7, < 2.10)
+      net-ssh (>= 2.9, < 4.0)
       safe_yaml (~> 1.0)
       thor (~> 0.18)
     thor (0.19.1)
@@ -64,4 +72,4 @@ DEPENDENCIES
   rspec (~> 3.3.0)
 
 BUNDLED WITH
-   1.11.0
+   1.11.2

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -534,7 +534,13 @@ module Kitchen
       end
 
       def role_name
-        File.basename(roles) == 'roles' ? '' : File.basename(roles)
+        if config[:role_name]
+          config[:role_name]
+        elsif File.basename(roles) == 'roles' 
+          ''
+        else
+          File.basename(roles)
+        end
       end
 
       def modules

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -141,6 +141,21 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
     end
   end
 
+  describe '#role_name' do
+    it 'should be empty if the roles_path ends with "roles"' do
+      config[:roles_path] = '/some/path/to/roles'
+      expect(provisioner.send(:role_name)).to eq '' 
+    end
+    it 'should be the basename of the roles_path does not end with "roles"' do
+      config[:roles_path] = '/some/path'
+      expect(provisioner.send(:role_name)).to eq 'path'
+    end
+    it 'should be the value from configuration if defined' do
+      config[:role_name] = 'my-role'
+      expect(provisioner.send(:role_name)).to eq 'my-role'
+    end
+  end
+
   describe '#prepare_roles' do
     it 'should correct cp when requirements_path not include path' do
       config[:requirements_path] = '.gitignore'
@@ -162,5 +177,4 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
       expect(File.exists?(File.join(sandbox_path, config[:requirements_path]))).to eq(true)
     end
   end
-
 end


### PR DESCRIPTION
This helps when the repo name does not match the name the role is published as.