### PR TITLE
Fixing an incorrect error message about default playbook locations

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -74,7 +74,7 @@ module Kitchen
 
         default_config :playbook do |provisioner|
           provisioner.calculate_path('default.yml', :file) ||
-            fail('No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default wrapper playbook for your role in test/integration/playbooks/default.yml or test/integration/default.yml')
+            fail('No playbook found or specified!  Please either set a playbook in your .kitchen.yml config, or create a default playbook in test/integration/<suite_name>/ansible/default.yml, test/integration/<suite_name>/default.yml, test/integration/default.yml or in default.yml in the top level')
         end
 
         default_config :roles_path do |provisioner|


### PR DESCRIPTION
Based on what I figured out inside a debugger:

```
[11] pry(#<Kitchen::Provisioner::Ansible::Config>)> base = config[:test_base_path]
=> "/Users/alexharvey/git/ansible-bind/test/integration"
[12] pry(#<Kitchen::Provisioner::Ansible::Config>)> File.join(base, instance.suite.name, 'ansible', path)
=> "/Users/alexharvey/git/ansible-bind/test/integration/slave/ansible/default.yml"
[13] pry(#<Kitchen::Provisioner::Ansible::Config>)> File.join(base, instance.suite.name, path)
=> "/Users/alexharvey/git/ansible-bind/test/integration/slave/default.yml"
[14] pry(#<Kitchen::Provisioner::Ansible::Config>)> File.join(base, path)
=> "/Users/alexharvey/git/ansible-bind/test/integration/default.yml"
[15] pry(#<Kitchen::Provisioner::Ansible::Config>)> File.join(Dir.pwd, path)
=> "/Users/alexharvey/git/ansible-bind/default.yml"
[16] pry(#<Kitchen::Provisioner::Ansible::Config>)> File.join(Dir.pwd) if path == 'roles'
=> nil
```