### PR TITLE
ansible 2.x patch

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -440,6 +440,7 @@ module Kitchen
           #{export_http_proxy}
           git clone git://github.com/ansible/ansible.git --recursive #{config[:root_path]}/ansible #{install_source_rev}
           #{sudo_env('easy_install')} pip
+          #{sudo_env('pip')} install -U setuptools
           #{sudo_env('pip')} install six paramiko PyYAML Jinja2 httplib2
         fi
         INSTALL
@@ -468,6 +469,7 @@ module Kitchen
 
           #{export_http_proxy}
           #{sudo_env('easy_install')} pip
+          #{sudo_env('pip')} install -U setuptools
           #{sudo_env('pip')} install ansible#{ansible_version}
         fi
         INSTALL


### PR DESCRIPTION
upgrade setuptools so that kitchen-ansible can install ansible 2.x versions.

this closes #178 .

after inspecting the code I think the same installation problem would arise when using source so I patched that as well.
