### PR TITLE
fix target paths

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -817,12 +817,15 @@ module Kitchen
           FileUtils.cp(galaxy_requirements, dest)
         end
 
-        # Detect whether we are running tests on a role
-        # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
-
         FileUtils.mkdir_p(File.join(tmp_roles_dir, role_name))
         Find.find(roles) do |source|
-          role_path = source.sub(roles, '')
+          # Detect whether we are running tests on a role
+          # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
+          role_path = source.sub(/#{roles}|\/roles/, '')
+          unless roles =~ /\/roles$/
+            role_path = "#{File.basename(roles)}/#{role_path}"
+          end
+
           target = File.join(tmp_roles_dir, role_path)
 
           Find.prune if config[:ignore_paths_from_root].include? File.basename(source)


### PR DESCRIPTION
Original fix didn't take into account running kitchen-ansible inside a
role as opposed to in the root of an ansible repository.  This patch
handles both locations by looking at the source roles path to see if it
ends in '/roles' or not & modifying the target path appropriately.

Regression in PR #182 
Relates to #173 