### PR TITLE
add/improve fedora support

### DIFF
--- a/lib/kitchen/provisioner/ansible/os.rb
+++ b/lib/kitchen/provisioner/ansible/os.rb
@@ -20,6 +20,7 @@
 require 'json'
 require 'kitchen/provisioner/ansible/os/debian'
 require 'kitchen/provisioner/ansible/os/redhat'
+require 'kitchen/provisioner/ansible/os/fedora'
 require 'kitchen/provisioner/ansible/os/amazon'
 require 'kitchen/provisioner/ansible/os/suse'
 
@@ -40,8 +41,10 @@ module Kitchen
           case platform
           when 'debian', 'ubuntu'
             return Debian.new(platform, config)
-          when 'redhat', 'centos', 'fedora'
+          when 'redhat', 'centos'
             return Redhat.new(platform, config)
+          when 'fedora'
+            return Fedora.new(platform, config)
           when 'amazon'
             return Amazon.new(platform, config)
           when 'suse', 'opensuse', 'sles'

--- a/lib/kitchen/provisioner/ansible/os/fedora.rb
+++ b/lib/kitchen/provisioner/ansible/os/fedora.rb
@@ -1,0 +1,60 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Michael Heap (<m@michaelheap.com>)
+#          Mark McKinstry
+#
+# Copyright (C) 2015 Michael Heap
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+  module Provisioner
+    module Ansible
+      class Os
+        class Fedora < Os
+          def install_command
+            <<-INSTALL
+
+            if [ ! $(which ansible) ]; then
+            #{redhat_yum_repo}
+            #{update_packages_command}
+            #{sudo_env('dnf')} -y install #{ansible_package_name} libselinux-python git python2-dnf
+            fi
+            INSTALL
+          end
+
+          def update_packages_command
+            @config[:update_package_repos] ? "#{sudo_env('dnf')} makecache" : nil
+          end
+
+          def ansible_package_name
+            if @config[:ansible_version] == 'latest' || @config[:ansible_version] == nil
+              "ansible"
+            else
+              "ansible#{@config[:ansible_version][0..2]}-#{@config[:ansible_version]}"
+            end
+          end
+
+          def redhat_yum_repo
+            if @config[:ansible_yum_repo]
+              <<-INSTALL
+              #{sudo_env('rpm')} -ivh #{@config[:ansible_yum_repo]}
+              INSTALL
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -85,7 +85,9 @@ module Kitchen
             cmd = <<-INSTALL
 
             if [ ! $(which ansible) ]; then
-              if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
+              if [ -f /etc/fedora-release ]; then
+                #{Kitchen::Provisioner::Ansible::Os::Fedora.new('fedora', config).install_command}
+              elif [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                 if [ -z `grep -q 'Amazon Linux' /etc/system-release` ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_command}
                 else

--- a/spec/kitchen/provisioner/ansible/os_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os_spec.rb
@@ -35,7 +35,7 @@ describe Kitchen::Provisioner::Ansible::Os do
       ['ubuntu', Kitchen::Provisioner::Ansible::Os::Debian],
       ['redhat', Kitchen::Provisioner::Ansible::Os::Redhat],
       ['centos', Kitchen::Provisioner::Ansible::Os::Redhat],
-      ['fedora', Kitchen::Provisioner::Ansible::Os::Redhat],
+      ['fedora', Kitchen::Provisioner::Ansible::Os::Fedora],
       ['amazon', Kitchen::Provisioner::Ansible::Os::Amazon],
       ['suse', Kitchen::Provisioner::Ansible::Os::Suse]
     ].each do |item|


### PR DESCRIPTION
fedora has switched from yum to dnf although yum commands still work for
now. python2-dnf also needs to be installed for it to work on fedora,
see
https://github.com/ansible/ansible-modules-extras/blob/e8dbb4e4f290486dbcb114e35ec10205649d7a17/packaging/os/dnf.py#L128-L132