### PR TITLE
Set correct role target path when using custom role name.

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -835,7 +835,7 @@ module Kitchen
           # If so, make sure to copy into VM so dir structure is like: /tmp/kitchen/roles/role_name
           role_path = source.sub(/#{roles}|\/roles/, '')
           unless roles =~ /\/roles$/
-            role_path = "#{File.basename(roles)}/#{role_path}"
+            role_path = "#{role_name}/#{role_path}"
           end
 
           target = File.join(tmp_roles_dir, role_path)

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -185,5 +185,15 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
 
       expect { provisioner.send(:prepare_roles) }.to_not raise_error
     end
+
+    it 'should correct cp when role_name is set' do
+      config[:role_name] = 'my-role'
+
+      sandbox_path = Dir.mktmpdir
+      allow(provisioner).to receive(:sandbox_path).and_return(sandbox_path)
+
+      expect { provisioner.send(:prepare_roles) }.to_not raise_error
+      expect(Dir.entries(File.join(sandbox_path, 'roles', config[:role_name])).size).to be > 2
+    end
   end
 end


### PR DESCRIPTION
When using custom role name, directory is created but content is copied to the wrong path (basename is used).