### PR TITLE
Fix RHEL and CentOS dependencies when using pip

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -459,7 +459,7 @@ module Kitchen
           if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
             #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_epel_repo}
             #{update_packages_redhat_cmd}
-            #{sudo_env('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev libffi-devel libssl-devel
+            #{sudo_env('yum')} -y install libselinux-python python2-devel git python-setuptools python-setuptools-dev libffi-devel openssl-devel gcc
           else
             if [ -f /etc/SUSE-brand ] || [ -f /etc/SuSE-release ]; then
               #{sudo_env('zypper')} ar #{python_sles_repo}


### PR DESCRIPTION
When installing Ansible using `pip` it will pull in cryptography as a
dependency. This needs to compile some things from source. Looks like
`libssl-devel` was added in error to the RHEL family. This should be
`openssl-devel`. Also, the `gcc` compiler needs to be available.
Depending on the image used when testing, this may not be baked in.