### PR TITLE
Adds support for Alpine-based machines.

### DIFF
--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 module Kitchen
   module Ansible
-    VERSION = '0.45.4'
+    VERSION = '0.45.5'
   end
 end

--- a/lib/kitchen/provisioner/ansible/os.rb
+++ b/lib/kitchen/provisioner/ansible/os.rb
@@ -23,6 +23,7 @@ require 'kitchen/provisioner/ansible/os/redhat'
 require 'kitchen/provisioner/ansible/os/fedora'
 require 'kitchen/provisioner/ansible/os/amazon'
 require 'kitchen/provisioner/ansible/os/suse'
+require 'kitchen/provisioner/ansible/os/alpine'
 
 module Kitchen
   module Provisioner
@@ -49,6 +50,8 @@ module Kitchen
             return Amazon.new(platform, config)
           when 'suse', 'opensuse', 'sles'
             return Suse.new(platform, config)
+          when 'alpine'
+            return Alpine.new(platform, config)
           end
 
           nil

--- a/lib/kitchen/provisioner/ansible/os/alpine.rb
+++ b/lib/kitchen/provisioner/ansible/os/alpine.rb
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Martin Etmajer (<martin@etmajer.com>)
+#
+# Copyright (C) 2016 Martin Etmajer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Kitchen
+  module Provisioner
+    module Ansible
+      class Os
+        class Alpine < Os
+          def update_packages_command
+            @config[:update_package_repos] ? "#{sudo_env('apk')} update" : nil
+          end
+
+          def install_command
+            <<-INSTALL
+
+            if [ ! $(which ansible) ]; then
+              #{update_packages_command}
+              #{sudo_env('apk')} add ansible git
+            fi
+            INSTALL
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -95,6 +95,8 @@ module Kitchen
                 fi
               elif [ -f /etc/SuSE-release ] || [ -f /etc/SUSE-brand ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Suse.new('suse', config).install_command}
+              elif [ -f /etc/alpine-release ] || [ -d /etc/apk ]; then
+                #{Kitchen::Provisioner::Ansible::Os::Alpine.new('alpine', config).install_command}
               else
                 #{Kitchen::Provisioner::Ansible::Os::Debian.new('debian', config).install_command}
               fi
@@ -177,6 +179,9 @@ module Kitchen
                 #{update_packages_suse_cmd}
                 #{sudo_env('zypper')} --non-interactive install ruby ruby-devel ca-certificates ca-certificates-cacert ca-certificates-mozilla
                 #{sudo_env('gem')} sources --add https://rubygems.org/
+            elif [ -f /etc/alpine-release ]  || [ -d /etc/apk ]; then
+                #{update_packages_alpine_cmd}
+                #{sudo_env('apk')} add ruby ruby-dev ruby-io-console ca-certificates
             else
               if [ ! $(which ruby) ]; then
                 #{update_packages_debian_cmd}
@@ -274,7 +279,7 @@ module Kitchen
 
         # Prevent failure when ansible package installation doesn't contain /etc/ansible
         commands << [
-          sudo_env("bash -c '[ -d /etc/ansible ] || mkdir /etc/ansible'")
+          sudo_env("sh -c '[ -d /etc/ansible ] || mkdir /etc/ansible'")
         ]
 
         commands << [
@@ -717,6 +722,10 @@ module Kitchen
 
       def update_packages_redhat_cmd
         Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).update_packages_command
+      end
+
+      def update_packages_alpine_cmd
+        Kitchen::Provisioner::Ansible::Os::Alpine.new('alpine', config).update_packages_command
       end
 
       def python_sles_repo

--- a/spec/kitchen/provisioner/ansible/os_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os_spec.rb
@@ -37,7 +37,8 @@ describe Kitchen::Provisioner::Ansible::Os do
       ['centos', Kitchen::Provisioner::Ansible::Os::Redhat],
       ['fedora', Kitchen::Provisioner::Ansible::Os::Fedora],
       ['amazon', Kitchen::Provisioner::Ansible::Os::Amazon],
-      ['suse', Kitchen::Provisioner::Ansible::Os::Suse]
+      ['suse', Kitchen::Provisioner::Ansible::Os::Suse],
+      ['alpine', Kitchen::Provisioner::Ansible::Os::Alpine]
     ].each do |item|
       it "return the correct class for '#{item[0]}'" do
         c = Kitchen::Provisioner::Ansible::Os.make(item[0], [])


### PR DESCRIPTION
This PR adds support for Alpine-based machines. Currently requires `require_ansible_repo: true` and `require_ruby_for_busser: true`. Example `.kitchen.yml`:

```
provisioner:
  name: ansible_playbook
  hosts: test-kitchen
  require_ansible_repo: true
  require_ansible_omnibus: false
  require_ruby_for_busser: true
  require_chef_for_busser: false

verifier:
  ruby_bindir: /usr/bin

driver:
  name: docker_cli

transport:
  name: docker_cli

platforms:
- name: alpine  
  driver_config:
    run_command:
    - apk add --no-cache sudo

suites:
- name: default
```