### PR TITLE
Use a more robust method for custom ansible.cfg

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -76,7 +76,6 @@ module Kitchen
         default_config :ignore_paths_from_root, []
         default_config :role_name, nil
         default_config :additional_copy_role_path, false
-        default_config :ansible_cfg_path, 'ansible.cfg'
 
         default_config :playbook do |provisioner|
           provisioner.calculate_path('default.yml', :file) ||
@@ -134,6 +133,10 @@ module Kitchen
 
         default_config :kerberos_conf_file do |provisioner|
           provisioner.calculate_path('kerberos_conf', :file)
+        end
+
+        default_config :ansible_cfg_path do |provisioner|
+          provisioner.calculate_path('ansible.cfg', :file)
         end
 
         def initialize(config = {})

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -602,6 +602,10 @@ module Kitchen
         config[:additional_copy_path]
       end
 
+      def ansible_cfg_path
+        config[:ansible_cfg_path]
+      end
+
       def recursive_additional_copy
         config[:recursive_additional_copy_path]
       end
@@ -857,9 +861,9 @@ module Kitchen
       def prepare_ansible_cfg
         info('Preparing ansible.cfg file')
         ansible_config_file = "#{File.join(sandbox_path, 'ansible.cfg')}"
-        if File.exist?(config[:ansible_cfg_path])
+        if !ansible_cfg_path.nil? && File.exist?(ansible_cfg_path)
           info('Found existing ansible.cfg')
-          FileUtils.cp_r(config[:ansible_cfg_path], ansible_config_file)
+          FileUtils.cp_r(ansible_cfg_path, ansible_config_file)
         else
           info('Empty ansible.cfg generated')
           File.open(ansible_config_file, 'wb') do |file|


### PR DESCRIPTION
This method will search many of the same common directories as other
files for an `ansible.cfg` file while still allowing for it to be
specified by the end user.