### PR TITLE
Add ability to ignore file extensions

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -73,6 +73,7 @@ module Kitchen
         default_config :ansible_inventory, nil
         default_config :ansible_inventory_file, nil
         default_config :ansible_limit, nil
+        default_config :ignore_extensions_from_root, ['.pyc']
         default_config :ignore_paths_from_root, []
         default_config :role_name, nil
         default_config :additional_copy_role_path, false

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -858,6 +858,7 @@ module Kitchen
           target = File.join(tmp_roles_dir, role_path)
 
           Find.prune if config[:ignore_paths_from_root].include? File.basename(source)
+          Find.prune if config[:ignore_extensions_from_root].include? File.extname(source)
           if File.directory?(source)
             FileUtils.mkdir_p(target)
           else
@@ -934,9 +935,10 @@ module Kitchen
         info('Preparing additional_copy_path')
         additional_files.each do |file|
            destination = File.join(sandbox_path, File.basename(file))
+           Find.prune if config[:ignore_paths_from_root].include? File.basename(file)
+           Find.prune if config[:ignore_extensions_from_root].include? File.extname(file)
            if File.directory?(file)
              info("Copy dir: #{file} #{destination}")
-             Find.prune if config[:ignore_paths_from_root].include? File.basename(file)
              FileUtils.mkdir_p(destination)
            else
              info("Copy file: #{file} #{destination}")
@@ -948,6 +950,7 @@ module Kitchen
           Find.find(file) do |files|
             destination = File.join(sandbox_path, files)
             Find.prune if config[:ignore_paths_from_root].include? File.basename(files)
+            Find.prune if config[:ignore_extensions_from_root].include? File.extname(files)
             if File.directory?(files)
               FileUtils.mkdir_p(destination)
             else

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -63,6 +63,7 @@ hosts |  | Create Ansible hosts file for localhost with this server group
 http_proxy | nil | Use HTTP proxy when installing Ansible, packages and running Ansible
 https_proxy | nil | Use HTTPS proxy when installing Ansible, packages and running Ansible
 idempotency_test | false | Enable to test Ansible playbook idempotency
+ignore_extensions_from_root | ['.pyc'] | allow extensions to be ignored when copying from roles and ansible cfg
 ignore_paths_from_root | [] | allow extra paths to be ignored when copying from roles and ansible cfg
 kerberos_conf_file | | Path of krb5.conf file using in Windows support
 library_plugins_path | library | Ansible repo library plugins directory


### PR DESCRIPTION
This is similar to the `ignore_paths_from_root` option except it only
applies to file extensions. Copying certain files, `*.pyc` files for
example, may not be desirable in all scenarios. This fixes #209.