### PR TITLE
Fix incorrect additional_copy_path variable

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -819,8 +819,8 @@ module Kitchen
         roles_paths = []
         roles_paths << File.join(config[:root_path], 'roles') unless config[:roles_path].nil?
         if config[:additional_copy_role_path]
-          config[:additional_copy_role_path].each do |additional_role_path|
-            roles_paths << File.join(config[:root_path], File.basename(additional_role_path))
+          config[:additional_copy_path].each do |path|
+            roles_paths << File.join(config[:root_path], File.basename(path))
           end
         end
         if roles_paths.empty?


### PR DESCRIPTION
The `additional_copy_role_path` variable was being used to add to the
`roles_path` which is incorrect. This variable is just a boolean to
indicate whether the paths in `additional_copy_path` should be included
into `roles_path`.