### PR TITLE
SSH Known Host Ports

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -299,9 +299,9 @@ module Kitchen
             info("Add #{host} to ~/.ssh/known_hosts")
             if host.include? ':'
               stripped_host, port = host.split(':')
-              commands << "ssh-keyscan -p #{port} #{stripped_host} > ~/.ssh/known_hosts 2> /dev/null"
+              commands << "ssh-keyscan -p #{port} #{stripped_host} >> ~/.ssh/known_hosts 2> /dev/null"
             else
-              commands << "ssh-keyscan #{host} > ~/.ssh/known_hosts 2> /dev/null"
+              commands << "ssh-keyscan #{host} >> ~/.ssh/known_hosts 2> /dev/null"
             end
           end
         end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -297,7 +297,12 @@ module Kitchen
         if config[:ssh_known_hosts]
           config[:ssh_known_hosts].each do |host|
             info("Add #{host} to ~/.ssh/known_hosts")
-            commands << "ssh-keyscan #{host} > ~/.ssh/known_hosts 2> /dev/null"
+            if host.include? ':'
+              stripped_host, port = host.split(':')
+              commands << "ssh-keyscan -p #{port} #{stripped_host} > ~/.ssh/known_hosts 2> /dev/null"
+            else
+              commands << "ssh-keyscan #{host} > ~/.ssh/known_hosts 2> /dev/null"
+            end
           end
         end
 


### PR DESCRIPTION
Hi there, thanks for the very useful gem!

My workplace uses Bitbucket Server (née Stash) for hosting our repositories. A particular quirk of this application is that it hosts its ssh interface on port `7999` rather than the much more standard `22`. This PR modifies the logic in the `ssh_known_hosts` code to allow specifying a port after a colon in the config to pass that as a parameter to `ssh-keyscan`. An example config block looks like this:

```
  ssh_known_hosts:
    - bitbucket.redacted.com:7999
    - github.com
```

In validating this feature, I believe I also found a minor bug where specifying multiple `ssh_known_host` entries would only leave the final entry in `~/.ssh/known_hosts`. This is because the keyscan code was using a truncating redirect (`>`) instead of an appending one (`>>`). I've changed that here, too.