### PR TITLE
source ansible install: allow specification of a repo URL

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -63,6 +63,7 @@ module Kitchen
         default_config :ansible_connection, 'local'
         default_config :update_package_repos, true
         default_config :require_ansible_source, false
+        default_config :ansible_source_url, 'git://github.com/ansible/ansible.git'
         default_config :ansible_source_rev, nil
         default_config :http_proxy, nil
         default_config :https_proxy, nil

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -452,7 +452,7 @@ module Kitchen
           fi
 
           #{export_http_proxy}
-          git clone git://github.com/ansible/ansible.git --recursive #{config[:root_path]}/ansible #{install_source_rev}
+          git clone #{config[:ansible_source_url]} --recursive #{config[:root_path]}/ansible #{install_source_rev}
           #{sudo_env('easy_install')} pip
           #{sudo_env('pip')} install -U setuptools
           #{sudo_env('pip')} install six paramiko PyYAML Jinja2 httplib2

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -43,6 +43,7 @@ ansible_omnibus_url | `https://raw.githubusercontent.com` `/neillturner/omnibus-
 ansible_platform | Naively tries to determine | OS platform of server
 ansible_playbook_command | | Override the Ansible playbook command
 ansible_sles_repo | `http://download.opensuse.org/repositories` `/systemsmanagement/SLE_12` `/systemsmanagement.repo` | Zypper SuSE Ansible repo
+ansible_source_url | `git://github.com/ansible/ansible.git` | Git URL of Ansible source
 ansible_source_rev | | Branch or tag to install Ansible source
 ansible_sudo | true | Determines whether `ansible-playbook` is executed as root or as the current authenticated user
 ansible_vault_password_file | | Path to Ansible Vault password file


### PR DESCRIPTION
Adds a new configuration parameter 'ansible_source_url' that will be used if set to fetch Ansible in a source install.