### PR TITLE
os detection: eliminate error in output

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -87,7 +87,7 @@ module Kitchen
             if [ ! $(which ansible) ]; then
               if [ -f /etc/fedora-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Fedora.new('fedora', config).install_command}
-              elif [ `grep -q 'Amazon Linux' /etc/system-release` ]; then
+              elif [ -f /etc/system-release ] && [ `grep -q 'Amazon Linux' /etc/system-release` ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Amazon.new('amazon', config).install_command}
               elif [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_command}


### PR DESCRIPTION
eliminates an error (non-fatal) in the output regarding OS detection

```
       Preparing lookup_plugins
       nothing to do for lookup_plugins
       Finished Preparing files for transfer
       Installing ansible, will try to determine platform os
       grep: /etc/system-release: No such file or directory       <----------
Ign http://archive.ubuntu.com trusty InRelease
Get:1 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]
Get:2 http://archive.ubuntu.com trusty-security InRelease [65.9 kB]
Hit http://archive.ubuntu.com trusty Release.gpg     
```