### PR TITLE
Fix install from pip running multiple times

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -455,7 +455,7 @@ module Kitchen
         ansible_version = "==#{config[:ansible_version]}" unless config[:ansible_version] == 'latest'
 
         <<-INSTALL
-        if [ ! -d #{config[:root_path]}/ansible ]; then
+        if [ ! $(which ansible) ]; then
           if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
             #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_epel_repo}
             #{update_packages_redhat_cmd}


### PR DESCRIPTION
When using the `require_pip` option to have Ansible installed using
`pip`, the install will happen each time a `converge` is run which can
be time consuming. This change simply looks for `ansible` in the path
instead of relying on the presence of an Ansible configuration file.

Not sure why the configuration file was used as the guard to prevent the 
`pip` install from running multiple times. Perhaps a change made the guard 
longer work or the guard only works on certain platforms. I can say that it 
doesn't work on `centos/7` boxes.