### PR TITLE
Darwin homebrew stops with prompt

### DIFF
--- a/lib/kitchen/provisioner/ansible/os/darwin.rb
+++ b/lib/kitchen/provisioner/ansible/os/darwin.rb
@@ -25,7 +25,7 @@ module Kitchen
 
           def install_command
             <<-INSTALL
-            /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+            /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" </dev/null
             /usr/local/bin/brew install ansible
             INSTALL
           end


### PR DESCRIPTION
The homebrew installer is now prompting on MacOS: "Press RETURN to continue or any other key to abort".
This fixes it by stopping stdin from being a TTY.
See: https://stackoverflow.com/questions/25535407/bypassing-prompt-to-press-return-in-homebrew-install-script