### PR TITLE
Allow Ansible package name to be overridden with an 'ansible_package_name' config option, for CentOS/RedHat

### DIFF
--- a/lib/kitchen/provisioner/ansible/os/redhat.rb
+++ b/lib/kitchen/provisioner/ansible/os/redhat.rb
@@ -42,11 +42,21 @@ module Kitchen
             @config[:enable_yum_epel] ? sudo_env('yum install epel-release -y') : nil
           end
 
-          def ansible_package_name
-            if @config[:ansible_version] == 'latest' || @config[:ansible_version] == nil
-              "ansible"
+          def ansible_package_version_suffix
+            return unless @config[:ansible_version] && @config[:ansible_version] != 'latest'
+
+            if @config[:ansible_package_name]
+              "-#{@config[:ansible_version]}"
             else
-              "ansible#{@config[:ansible_version][0..2]}-#{@config[:ansible_version]}"
+              "#{@config[:ansible_version][0..2]}-#{@config[:ansible_version]}"
+            end
+          end
+
+          def ansible_package_name
+            if @config[:ansible_package_name]
+              "#{@config[:ansible_package_name]}#{ansible_package_version_suffix}"
+            else
+              "ansible#{ansible_package_version_suffix}"
             end
           end
 

--- a/spec/kitchen/provisioner/ansible/os/redhat_spec.rb
+++ b/spec/kitchen/provisioner/ansible/os/redhat_spec.rb
@@ -1,0 +1,61 @@
+# -*- encoding: utf-8 -*-
+#
+# Author:: Mike Mead (<hi@mikemead.me>)
+#
+# Copyright (C) 2017 Mike Mead
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+require 'kitchen/provisioner/ansible/os'
+require 'kitchen/provisioner/ansible/os/redhat'
+
+include Kitchen::Ansible::TestHelpers
+
+describe Kitchen::Provisioner::Ansible::Os::Redhat do
+  let (:redhat) { Kitchen::Provisioner::Ansible::Os.make('redhat', config) }
+  describe 'install_command' do
+    subject(:install_command) { redhat.install_command }
+
+    context 'when no ansible version is specified in the config' do
+      let (:config) { empty_config }
+
+      it { is_expected.to match /yum -y install ansible / }
+    end
+
+    context 'when an ansible version (1.2.3) is specified in the config' do
+      let (:config) { config_with(ansible_version: "1.2.3") }
+
+      it { is_expected.to match /yum -y install ansible1.2-1.2.3 / }
+    end
+
+    context 'when an ansible version (latest) is specified in the config' do
+      let (:config) { config_with(ansible_version: "latest") }
+
+      it { is_expected.to match /yum -y install ansible / }
+    end
+
+    context 'when no ansible package name (ansible1) is specified in the config' do
+      let (:config) { config_with(ansible_package_name: "ansible1") }
+
+      it { is_expected.to match /yum -y install ansible1 / }
+    end
+
+    context 'when no ansible package name (ansible1) and version (1.2.3) is specified in the config' do
+      let (:config) { config_with(ansible_package_name: "ansible1", ansible_version: "1.2.3") }
+
+      it { is_expected.to match /yum -y install ansible1-1.2.3 / }
+    end
+  end
+end


### PR DESCRIPTION
**Problem:**
When using the CentOS extras repo, not EPEL, the Ansible package name is always `ansible`. The current behaviour assumes that the package name includes the major and minor version number, when you're trying to pin at a particular version.

i.e. `yum install ansible2.3-2.3.0.0` vs `yum install ansible-2.3.0.0`

**Solution:**
To allow an older version of Ansible to be installed, from the CentOS extras repo, whilst maintaining current behavior; A new config option has been added `ansible_package_name`, which when combined with `ansible_version` will address the problem above.