### PR TITLE
Add an option to ignore existing ansible.cfg

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -86,6 +86,7 @@ module Kitchen
         default_config :custom_post_install_command, nil
         default_config :custom_post_play_command, nil
         default_config :show_command_output, false
+        default_config :ignore_ansible_cfg, false
 
         default_config :playbook do |provisioner|
           provisioner.calculate_path('default.yml', :file) ||

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -280,7 +280,8 @@ module Kitchen
         prepare_inventory
         prepare_modules
         prepare_roles
-        prepare_ansible_cfg
+        if not config[:ignore_ansible_cfg]
+          prepare_ansible_cfg
         prepare_group_vars
         prepare_additional_copy_path
         prepare_host_vars

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -282,6 +282,7 @@ module Kitchen
         prepare_roles
         if not config[:ignore_ansible_cfg]
           prepare_ansible_cfg
+        end
         prepare_group_vars
         prepare_additional_copy_path
         prepare_host_vars

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -280,9 +280,7 @@ module Kitchen
         prepare_inventory
         prepare_modules
         prepare_roles
-        if not config[:ignore_ansible_cfg]
-          prepare_ansible_cfg
-        end
+        prepare_ansible_cfg
         prepare_group_vars
         prepare_additional_copy_path
         prepare_host_vars
@@ -964,7 +962,7 @@ module Kitchen
       def prepare_ansible_cfg
         info('Preparing ansible.cfg file')
         ansible_config_file = "#{File.join(sandbox_path, 'ansible.cfg')}"
-        if !ansible_cfg_path.nil? && File.exist?(ansible_cfg_path)
+        if !ansible_cfg_path.nil? && File.exist?(ansible_cfg_path) && !config[:ignore_ansible_cfg]
           info('Found existing ansible.cfg')
           FileUtils.cp_r(ansible_cfg_path, ansible_config_file)
         else

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -102,6 +102,7 @@ ssh_known_hosts | | List of hosts that should be added to ~/.ssh/known_hosts
 sudo_command | sudo -E | `sudo` command; change to `sudo -E -H` to be consistent with Ansible
 update_package_repos | true | Update OS repository metadata
 wait_for_retry | 30 | number of seconds to wait before retrying converge command
+ignore_ansible_cfg | false | If true, values from ansible.cfg file will not be loaded.
 
 ## Ansible Inventory 
 


### PR DESCRIPTION
To make it possible to overwrite values in .kitchen.yml. Default false which means it won't impact existing users who want to load their ansible cfg files.