### PR TITLE
Ensure rake version less than 11 is used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
   - 2.3.1
   - 2.3.4
   - 2.4.1

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rspec', '~> 3.3.0'
+gem 'rake', '< 11.0'


### PR DESCRIPTION
the method last_comment was removed in rake 11 and throws the following errors when running the tests (bundle exec rake test)

NoMethodError: undefined method `last_comment' for #<Rake::Application:0x000055f63c601818>
