### PR TITLE
feature: introduce keep_playbook_path to support playbook in dirs better

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -90,6 +90,7 @@ module Kitchen
         default_config :show_command_output, false
         default_config :ignore_ansible_cfg, false
         default_config :galaxy_ignore_certs, false
+        default_config :keep_playbook_path, false
 
         default_config :playbook do |provisioner|
           provisioner.calculate_path('default.yml', :file) ||

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -422,7 +422,7 @@ module Kitchen
             extra_vars_file,
             tags(idempotence),
             ansible_extra_flags,
-            "#{File.join(config[:root_path], File.basename(config[:playbook]))}"
+            playbook_remote_path
           ].join(' ')
         end
         result = _run(cmd)
@@ -573,7 +573,8 @@ module Kitchen
       end
 
       def tmp_playbook_path
-        File.join(sandbox_path, File.basename(playbook))
+        return File.join(sandbox_path, playbook).to_s if config[:keep_playbook_path]
+        File.join(sandbox_path, File.basename(playbook)).to_s
       end
 
       def tmp_host_vars_dir
@@ -635,6 +636,11 @@ module Kitchen
 
       def playbook
         config[:playbook]
+      end
+
+      def playbook_remote_path
+        return File.join(config[:root_path], config[:playbook]).to_s if config[:keep_playbook_path]
+        File.join(config[:root_path], File.basename(config[:playbook])).to_s
       end
 
       def hosts
@@ -1034,6 +1040,7 @@ module Kitchen
       def prepare_playbook
         info('Preparing playbook')
         debug("Copying playbook from #{playbook} to #{tmp_playbook_path}")
+        FileUtils.mkdir_p(File.dirname(tmp_playbook_path)) if config[:keep_playbook_path]
         FileUtils.cp_r(playbook, tmp_playbook_path)
       end
 

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -79,6 +79,7 @@ idempotency_skip_tags | [] | Adds a `--skip-tags` parameter with the specified t
 ignore_extensions_from_root | ['.pyc'] | allow extensions to be ignored when copying from roles using additional_copy_role_path or doing recursive_additional_copy_path
 ignore_paths_from_root | [] | allow extra paths to be ignored when copying from roles using additional_copy_role_path or using recursive_additional_copy_path
 kerberos_conf_file | | Path of krb5.conf file using in Windows support
+keep_playbook_path | false | Keep directory structure of `playbook`, e.g. when including vars with relativ paths from playbook
 library_plugins_path | library | Ansible repo library plugins directory
 lookup_plugins_path | lookup_plugins | Ansible repo `lookup_plugins` directory
 max_retries | 1 | maximum number of retry attempts of converge command

--- a/spec/kitchen/provisioner/ansible_playbook_spec.rb
+++ b/spec/kitchen/provisioner/ansible_playbook_spec.rb
@@ -108,6 +108,40 @@ describe Kitchen::Provisioner::AnsiblePlaybook do
     end
   end
 
+  describe '#prepare playbook' do
+    it 'should correct cp with default options' do
+
+      config[:playbook] = '.gitignore'
+
+      sandbox_path = Dir.mktmpdir
+      allow(provisioner).to receive(:sandbox_path).and_return(sandbox_path)
+
+      expect { provisioner.send(:prepare_playbook) }.to_not raise_error
+      expect(File.exists?(File.join(sandbox_path, config[:playbook]))).to eq(true)
+    end
+    it 'should correct copy deep playbook into root_path by default' do
+
+      config[:playbook] = 'spec/data/requirements.yml'
+
+      sandbox_path = Dir.mktmpdir
+      allow(provisioner).to receive(:sandbox_path).and_return(sandbox_path)
+
+      expect { provisioner.send(:prepare_playbook) }.to_not raise_error
+      expect(File.exists?(File.join(sandbox_path, File.basename(config[:playbook])))).to eq(true)
+    end
+    it 'should correct copy deep playbook deep with keep_playbook_path=true' do
+
+      config[:playbook] = 'spec/data/requirements.yml'
+      config[:keep_playbook_path] = true
+
+      sandbox_path = Dir.mktmpdir
+      allow(provisioner).to receive(:sandbox_path).and_return(sandbox_path)
+
+      expect { provisioner.send(:prepare_playbook) }.to_not raise_error
+      expect(File.exists?(File.join(sandbox_path, config[:playbook]))).to eq(true)
+    end
+  end
+
   describe '#prepare_inventory' do
     it 'copies the inventory file to the sandbox when present' do
       allow(provisioner).to receive(:sandbox_path).and_return(Dir.mktmpdir)


### PR DESCRIPTION
In our Ansible setup we do have playbooks in `playbooks/` folder, e.g. `playbooks/site.yml`.

We need to include various `var_files` in playbooks which are relative to _playbook_, so it would help us to copy structure of `playbooks/` folder and run _ansible-playbook_ with respect to that path.

Currently we work-around this via `custom_pre_play_command`, but this is not maintainable well:

```yaml
custom_pre_play_command: "sed -i 's#- ../vars/services.yml#- vars/services.yml#g' /tmp/kitchen/site.yml"
```

This change introduces possibility to `keep_playbook_path` and run playbook with respect to its path in project.