### PR TITLE
Propose for fix for #297

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -89,6 +89,7 @@ module Kitchen
         default_config :custom_post_play_command, nil
         default_config :show_command_output, false
         default_config :ignore_ansible_cfg, false
+        default_config :ansible_cfg_overwrite, true
         default_config :galaxy_ignore_certs, false
         default_config :keep_playbook_path, false
 

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -984,14 +984,14 @@ module Kitchen
         end
       end
 
-      # copy ansible.cfg if found
+      # copy ansible.cfg if found and ansible_cfg_overwrite is set to true
       def prepare_ansible_cfg
         info('Preparing ansible.cfg file')
         ansible_config_file = "#{File.join(sandbox_path, 'ansible.cfg')}"
         if !ansible_cfg_path.nil? && File.exist?(ansible_cfg_path) && !config[:ignore_ansible_cfg]
           info('Found existing ansible.cfg')
           FileUtils.cp_r(ansible_cfg_path, ansible_config_file)
-        else
+        else if config[:ansible_cfg_overwrite]
           info('Empty ansible.cfg generated')
           File.open(ansible_config_file, 'wb') do |file|
             file.write("#no config parameters\n")

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -991,7 +991,7 @@ module Kitchen
         if !ansible_cfg_path.nil? && File.exist?(ansible_cfg_path) && !config[:ignore_ansible_cfg]
           info('Found existing ansible.cfg')
           FileUtils.cp_r(ansible_cfg_path, ansible_config_file)
-        else if config[:ansible_cfg_overwrite]
+        elsif config[:ansible_cfg_overwrite]
           info('Empty ansible.cfg generated')
           File.open(ansible_config_file, 'wb') do |file|
             file.write("#no config parameters\n")

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -36,6 +36,7 @@ ansible_binary_path | NULL | If specified this will override the location where 
 ansible_check | false | Sets the `--check` flag when running Ansible
 ansible_connection | local | use `ssh` if the host is not `localhost` (Linux) or `winrm` (Windows) or `none` if defined in inventory
 ansible_cfg_path | ansible.cfg | location of custom ansible.cfg to get copied into test environment
+ansible_cfg_overwrite | true | whether the ansible.cfg in the test environment should be overwritten or not.
 ansible_diff | false | Sets the `--diff` flag when running Ansible
 ansible_extra_flags |  | Additional options to pass to ansible-playbook, e.g. `'--skip-tags=redis'`
 ansible_host_key_checking | true | Strict host key checking in ssh


### PR DESCRIPTION
Added a new config option to choose wheter to overwrite the ansible.cfg in the test environment with an empty ansible.cfg if there is no ansible.cfg defined next to the .kitchen.yml