### PR TITLE
Fix error on second run of 'kitchen converge' when 'additional_copy_role_path' is set

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -921,10 +921,10 @@ module Kitchen
         roles_paths << File.join(config[:root_path], 'roles') unless config[:roles_path].nil?
         if config[:additional_copy_role_path]
           if config[:additional_copy_role_path].is_a? String
-            roles_paths << File.join(config[:root_path], File.basename(config[:additional_copy_role_path]))
+            roles_paths << File.join(config[:root_path], 'roles', File.basename(config[:additional_copy_role_path]))
           else
             config[:additional_copy_role_path].each do |path|
-              roles_paths << File.join(config[:root_path], File.basename(File.expand_path(path)))
+              roles_paths << File.join(config[:root_path], 'roles', File.basename(File.expand_path(path)))
             end
           end
         end
@@ -952,12 +952,12 @@ module Kitchen
         if config[:additional_copy_role_path]
           if config[:additional_copy_role_path].is_a? String
             debug("Using additional roles copy from #{File.expand_path(config[:additional_copy_role_path])}")
-            dest = File.join(sandbox_path, File.basename(File.expand_path(config[:additional_copy_role_path])))
+            dest = File.join(sandbox_path, 'roles', File.basename(File.expand_path(config[:additional_copy_role_path])))
             FileUtils.mkdir_p(File.dirname(dest))
             FileUtils.cp_r(File.expand_path(config[:additional_copy_role_path]), dest)
           else
             config[:additional_copy_role_path].each do |path|
-              dest = File.join(sandbox_path, File.basename(File.expand_path(path)))
+              dest = File.join(sandbox_path, 'roles', File.basename(File.expand_path(path)))
               FileUtils.mkdir_p(File.dirname(dest))
               FileUtils.cp_r(File.expand_path(path), dest)
             end


### PR DESCRIPTION
Previously, kitchen would throw an error on the second run of 'kitchen converge' when 'additional_copy_role_path' was set. See #304 for full details.

This PR fixes the issue by treating additional roles in the same way as the role under test e.g. 

* Additional roles are now uploaded to `/tmp/kitchen/roles` rather than `/tmp/kitchen`
* Additional roles are uploaded anew for each run of `kitchen converge`

Fixes #304