### PR TITLE
Fix Ansible install for Fedora 30

### DIFF
--- a/lib/kitchen/provisioner/ansible/os/fedora.rb
+++ b/lib/kitchen/provisioner/ansible/os/fedora.rb
@@ -29,7 +29,13 @@ module Kitchen
             if [ ! $(which ansible) ]; then
             #{redhat_yum_repo}
             #{update_packages_command}
-            #{sudo_env('dnf')} -y install #{ansible_package_name} libselinux-python git python2-dnf
+            FEDORA_RELEASE=$(rpm --query --queryformat="%{VERSION}" --file /etc/fedora-release)
+
+            if [ ${FEDORA_RELEASE} -le 28 ]; then
+              #{sudo_env('dnf')} -y install #{ansible_package_name} libselinux-python git python2-dnf
+            else
+              #{sudo_env('dnf')} -y install #{ansible_package_name} python3-libselinux git python3-dnf
+            fi
             fi
             INSTALL
           end


### PR DESCRIPTION
With the impending end-of-support for Python 2.x in Jan
2020, Fedora has started switching all Python support to
3.x. Fedora 30 has been the removal of Python 2.x packages
(see https://fedoraproject.org/wiki/Changes/Mass_Python_2_Package_Removal).
Because of this, there is no longer a python2-dnf package, so
the dnf install fails.

This command adds a check for Fedora release. If less than or
equal to 28, then use the previous install command. Starting
with 29, Fedora's Ansible is python3 based, so flip libselinux
and dnf python packages to be their python3 counterparts.