### PR TITLE
feature: support ansible collections

### DIFF
--- a/lib/kitchen/provisioner/ansible/config.rb
+++ b/lib/kitchen/provisioner/ansible/config.rb
@@ -55,6 +55,7 @@ module Kitchen
         default_config :require_windows_support, false
         default_config :require_pip, false
         default_config :requirements_path, false
+        default_config :requirements_collection_path, false
         default_config :ssh_known_hosts, nil
         default_config :additional_ssh_private_keys, nil
         default_config :ansible_verbose, false

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -373,6 +373,10 @@ module Kitchen
           commands << ansible_galaxy_command
         end
 
+        if galaxy_requirements_collections
+          commands << ansible_galacy_collection_command
+        end
+
         if kerberos_conf_file
           commands << [
             sudo_env('cp -f'), File.join(config[:root_path], 'krb5.conf'), '/etc'
@@ -466,6 +470,18 @@ module Kitchen
             galaxy_cert_ignore,
             '-p', File.join(config[:root_path], 'roles'),
             '-r', File.join(config[:root_path], galaxy_requirements)
+        ].join(' ')
+        cmd = "https_proxy=#{https_proxy} #{cmd}" if https_proxy
+        cmd = "http_proxy=#{http_proxy} #{cmd}" if http_proxy
+        cmd = "no_proxy=#{no_proxy} #{cmd}" if no_proxy
+        cmd
+      end
+
+      def ansible_galacy_collection_command
+        cmd = [
+          'ansible-galaxy', 'collection', 'install', '--force',
+          '-p', File.join(config[:root_path], 'collections'),
+          '-r', File.join(config[:root_path], galaxy_requirements_collections)
         ].join(' ')
         cmd = "https_proxy=#{https_proxy} #{cmd}" if https_proxy
         cmd = "http_proxy=#{http_proxy} #{cmd}" if http_proxy
@@ -627,6 +643,10 @@ module Kitchen
 
       def galaxy_requirements
         config[:requirements_path] || nil
+      end
+
+      def galaxy_requirements_collections
+        config[:requirements_collection_path] || nil
       end
 
       def env_vars

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -264,7 +264,7 @@ module Kitchen
       end
 
       def init_command
-        dirs = %w(modules roles group_vars host_vars)
+        dirs = %w(modules roles group_vars host_vars collections)
                .map { |dir| File.join(config[:root_path], dir) }.join(' ')
         cmd = "#{sudo_env('rm')} -rf #{dirs};"
         cmd += " mkdir -p #{config[:root_path]}"

--- a/provisioner_options.md
+++ b/provisioner_options.md
@@ -98,6 +98,7 @@ require_pip | false | Set to `true` if Ansible is to be installed through `pip`)
 require_ruby_for_busser | false | Install Ruby to run Busser for tests
 require_windows_support | false | Install [Windows support](http://docs.ansible.com/ansible/intro_windows.html)
 requirements_path | | Path to Ansible Galaxy requirements
+requirements_collection_path | | Path to Ansible Galaxy requirements
 retry_on_exit_code | [] | Array of exit codes to retry converge command against
 role_name | | use when the repo name does not match the name the role is published as.
 roles_path | roles | Ansible repo roles directory


### PR DESCRIPTION
ansible 2.9.x introduced `collections`. a `collection` can be installed with `ansible-galaxy` but `kitchen-ansible` does not support it. introduce `requirements_collection_path`, which is almost same as `requirements_path`.