### PR TITLE
Make command compatible with ZSH

### DIFF
--- a/lib/kitchen-ansible/version.rb
+++ b/lib/kitchen-ansible/version.rb
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 module Kitchen
   module Ansible
-    VERSION = '0.52.0'.freeze
+    VERSION = '0.53.0'.freeze
   end
 end

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -311,7 +311,7 @@ module Kitchen
         commands = []
 
         commands << [
-          "if [ $(uname -s) == 'FreeBSD' ]; then ETC_ANSIBLE='/usr/local/etc/ansible'; else ETC_ANSIBLE='/etc/ansible'; fi"
+          "if [ $(uname -s) = 'FreeBSD' ]; then ETC_ANSIBLE='/usr/local/etc/ansible'; else ETC_ANSIBLE='/etc/ansible'; fi"
         ]
         # Prevent failure when ansible package installation doesn't contain /etc/ansible
         commands << [


### PR DESCRIPTION
This change makes the commands run by the provisioner compatible with ZSH. This change fixes compatibility with targets where ZSH is the default shell.

Fixes neillturner/kitchen-ansible#308