### PR TITLE
Changes that allow kitchen-ansible to work with kitchen-docker

### DIFF
--- a/lib/kitchen/provisioner/ansible/os.rb
+++ b/lib/kitchen/provisioner/ansible/os.rb
@@ -49,7 +49,7 @@ module Kitchen
             return Redhat.new(platform, config)
           when 'fedora'
             return Fedora.new(platform, config)
-          when 'amazon'
+          when 'amazon', 'amazonlinux'
             return Amazon.new(platform, config)
           when 'suse', 'opensuse', 'sles'
             return Suse.new(platform, config)

--- a/lib/kitchen/provisioner/ansible/os.rb
+++ b/lib/kitchen/provisioner/ansible/os.rb
@@ -49,7 +49,7 @@ module Kitchen
             return Redhat.new(platform, config)
           when 'fedora'
             return Fedora.new(platform, config)
-          when 'amazon', 'amazonlinux'
+          when 'amazon'
             return Amazon.new(platform, config)
           when 'suse', 'opensuse', 'sles'
             return Suse.new(platform, config)

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -29,7 +29,7 @@ module Kitchen
               #{install_epel_repo}
               #{sudo_env('yum-config-manager')} --enable epel/x86_64
               #{sudo_env('yum')} -y install git
-              if [ `grep -q "Amazon Linux AMI" /etc/os-release` ]; then
+              if `grep -q "Amazon Linux AMI" /etc/os-release`; then
                 #{sudo_env('yum')} -y install #{ansible_package_name}
                 #{sudo_env('alternatives')} --set python /usr/bin/python2.6
                 #{sudo_env('yum')} clean all

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -29,12 +29,15 @@ module Kitchen
               #{install_epel_repo}
               #{sudo_env('yum-config-manager')} --enable epel/x86_64
               #{sudo_env('yum')} -y install git
+
               if `grep -q "Amazon Linux AMI" /etc/os-release`; then
+                ## Amazon Linux 1
                 #{sudo_env('yum')} -y install #{ansible_package_name}
                 #{sudo_env('alternatives')} --set python /usr/bin/python2.6
                 #{sudo_env('yum')} clean all
                 #{sudo_env('yum')} install yum-python26 -y
               else
+                ## Amazon Linux 2
                 #{sudo_env('amazon-linux-extras')} install -y ansible2
               fi
             fi

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -35,7 +35,7 @@ module Kitchen
                 #{sudo_env('yum')} clean all
                 #{sudo_env('yum')} install yum-python26 -y
               else
-                #{sudo_env('amazon-linux-extras') install -y ansible2
+                #{sudo_env('amazon-linux-extras')} install -y ansible2
               fi
             fi
             INSTALL

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -29,9 +29,11 @@ module Kitchen
               #{install_epel_repo}
               #{sudo_env('yum-config-manager')} --enable epel/x86_64
               #{sudo_env('yum')} -y install #{ansible_package_name} git
-              #{sudo_env('alternatives')} --set python /usr/bin/python2.6
-              #{sudo_env('yum')} clean all
-              #{sudo_env('yum')} install yum-python26 -y
+              if [ `grep -q "Amazon Linux AMI" /etc/os-release` ]; then
+                #{sudo_env('alternatives')} --set python /usr/bin/python2.6
+                #{sudo_env('yum')} clean all
+                #{sudo_env('yum')} install yum-python26 -y
+              fi
             fi
             INSTALL
           end

--- a/lib/kitchen/provisioner/ansible/os/amazon.rb
+++ b/lib/kitchen/provisioner/ansible/os/amazon.rb
@@ -28,11 +28,14 @@ module Kitchen
             if [ ! $(which ansible) ]; then
               #{install_epel_repo}
               #{sudo_env('yum-config-manager')} --enable epel/x86_64
-              #{sudo_env('yum')} -y install #{ansible_package_name} git
+              #{sudo_env('yum')} -y install git
               if [ `grep -q "Amazon Linux AMI" /etc/os-release` ]; then
+                #{sudo_env('yum')} -y install #{ansible_package_name}
                 #{sudo_env('alternatives')} --set python /usr/bin/python2.6
                 #{sudo_env('yum')} clean all
                 #{sudo_env('yum')} install yum-python26 -y
+              else
+                #{sudo_env('amazon-linux-extras') install -y ansible2
               fi
             fi
             INSTALL

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -91,6 +91,7 @@ module Kitchen
               if [ -f /etc/fedora-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Fedora.new('fedora', config).install_command}
               elif [ -f /etc/system-release ] && `grep -q 'Amazon Linux' /etc/system-release`; then
+                #{info('I HAVE FOUND AMAZON LINUX')}
                 #{Kitchen::Provisioner::Ansible::Os::Amazon.new('amazon', config).install_command}
               elif [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_command}

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -91,7 +91,6 @@ module Kitchen
               if [ -f /etc/fedora-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Fedora.new('fedora', config).install_command}
               elif [ -f /etc/system-release ] && `grep -q 'Amazon Linux' /etc/system-release`; then
-                #{info('I HAVE FOUND AMAZON LINUX')}
                 #{Kitchen::Provisioner::Ansible::Os::Amazon.new('amazon', config).install_command}
               elif [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_command}

--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -90,7 +90,7 @@ module Kitchen
             if [ ! $(which ansible) ]; then
               if [ -f /etc/fedora-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Fedora.new('fedora', config).install_command}
-              elif [ -f /etc/system-release ] && [ `grep -q 'Amazon Linux' /etc/system-release` ]; then
+              elif [ -f /etc/system-release ] && `grep -q 'Amazon Linux' /etc/system-release`; then
                 #{Kitchen::Provisioner::Ansible::Os::Amazon.new('amazon', config).install_command}
               elif [ -f /etc/centos-release ] || [ -f /etc/redhat-release ]; then
                 #{Kitchen::Provisioner::Ansible::Os::Redhat.new('redhat', config).install_command}


### PR DESCRIPTION
One additional note... In order for this to work with the official docker images from certain RHEL-based distributions, the `enable_yum_epel` must be set to true in a user's `.kitchen.yml`.