### PR TITLE
Use upstream Ubuntu ansible package for 20.04

### DIFF
--- a/lib/kitchen/provisioner/ansible/os/debian.rb
+++ b/lib/kitchen/provisioner/ansible/os/debian.rb
@@ -63,7 +63,11 @@ module Kitchen
                 ## later versions require interaction from user, so we must specify --yes
                 ## First try with -y flag, else if it fails, try without.
                 ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
-                #{sudo_env('add-apt-repository')} -y #{@config[:ansible_apt_repo]} || #{sudo_env('add-apt-repository')} #{@config[:ansible_apt_repo]}
+                ## There is no official Ubuntu 20.04 ansible release in the ppa, but Ubuntu has a package with the latest 2.9 Ansible
+                ## This "fixes" issue #321 for now
+                if `grep -q 'VERSION_ID=\"20.04\"' /etc/os-release`; then
+                  #{sudo_env('add-apt-repository')} -y #{@config[:ansible_apt_repo]} || #{sudo_env('add-apt-repository')} #{@config[:ansible_apt_repo]}
+                fi
               fi
               #{sudo_env('apt-get')} update
               #{sudo_env('apt-get')} -y install ansible#{ansible_debian_version}

--- a/lib/kitchen/provisioner/ansible/os/debian.rb
+++ b/lib/kitchen/provisioner/ansible/os/debian.rb
@@ -65,7 +65,7 @@ module Kitchen
                 ## "add-apt-repository: error: no such option: -y" is returned but is ok to ignore, we just retry
                 ## There is no official Ubuntu 20.04 ansible release in the ppa, but Ubuntu has a package with the latest 2.9 Ansible
                 ## This "fixes" issue #321 for now
-                if `grep -q 'VERSION_ID=\"20.04\"' /etc/os-release`; then
+                if ! `grep -q 'VERSION_ID=\"20.04\"' /etc/os-release`; then
                   #{sudo_env('add-apt-repository')} -y #{@config[:ansible_apt_repo]} || #{sudo_env('add-apt-repository')} #{@config[:ansible_apt_repo]}
                 fi
               fi


### PR DESCRIPTION
Salt has blocking issues around adding an official 20.04 ansible package. See https://github.com/ansible/ansible/issues/69203 & https://github.com/ansible/ansible/issues/69414. This works around #321

Ubuntu has a package of ansible 2.9.6 upstream in a standard repository, so for now we don't need point at the ppa. When the ppa has official packages for 20.04, this should be removed.