### PR TITLE
Fixed key permissions

### DIFF
--- a/lib/kitchen/provisioner/ansible_playbook.rb
+++ b/lib/kitchen/provisioner/ansible_playbook.rb
@@ -344,7 +344,15 @@ module Kitchen
 
         if config[:additional_ssh_private_keys]
           commands << [
-            sudo_env('cp -r'), File.join(config[:root_path], 'ssh_private_keys'), '~/.ssh'
+            sudo_env('chmod -R 600'), File.join(config[:root_path], 'ssh_private_keys/*')
+          ].join(' ')
+
+          commands << [
+            sudo_env('chown -R'), "#{instance.transport[:username]}:#{instance.transport[:username]}", File.join(config[:root_path], 'ssh_private_keys/*')
+          ].join(' ')
+
+          commands << [
+            sudo_env('cp -rp'), File.join(config[:root_path], 'ssh_private_keys/*'), '~/.ssh'
           ].join(' ')
         end
 


### PR DESCRIPTION
Before this fix, we'd be copying the entire `ssh_private_keys` directory from the role root path into `~/.ssh` with the user and group being set to `root:root`. 

This was problematic as tools like `git` don't look through the directory. The key files need to be at the root of `~/.ssh`.

This sets the file permissions on the keys and user/group ownership before copying them into `~/.ssh`(while preserving permissions)